### PR TITLE
ENH: Add '/fmu' and '/fmu/init' routes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ select = [
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
+known-third-party = ["fmu.settings"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/fmu_settings_api/v1/main.py
+++ b/src/fmu_settings_api/v1/main.py
@@ -1,6 +1,12 @@
 """The main router for /api/v1."""
 
-from fastapi import APIRouter, Depends
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from fmu.settings import get_fmu_directory
+from fmu.settings._init import init_fmu_directory
+from fmu.settings.resources.config import Config
+from pydantic import BaseModel
 
 from fmu_settings_api.config import settings
 from fmu_settings_api.deps import verify_auth_token
@@ -10,6 +16,61 @@ api_v1_router = APIRouter(
     tags=["v1"],
     dependencies=[Depends(verify_auth_token)],
 )
+
+
+class FMUDirPath(BaseModel):
+    """Path where a .fmu directory may exist."""
+
+    path: Path
+    """Path to the directory which should or will contain a .fmu directory."""
+
+
+@api_v1_router.post("/fmu")
+async def get_fmu_directory_session(fmu_dir_path: FMUDirPath) -> Config:
+    """Returns the configuration for the .fmu directory at 'path'."""
+    path = fmu_dir_path.path
+    try:
+        fmu_dir = get_fmu_directory(path)
+        return fmu_dir.config.load()
+    except PermissionError as e:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Permission denied accessing .fmu at {path}",
+        ) from e
+    except FileNotFoundError as e:
+        raise HTTPException(
+            status_code=404, detail=f"No .fmu directory found at {path}"
+        ) from e
+    except FileExistsError as e:
+        raise HTTPException(
+            status_code=409, detail=f".fmu exists at {path} but is not a directory"
+        ) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@api_v1_router.post("/fmu/init")
+async def init_fmu_directory_session(fmu_dir_path: FMUDirPath) -> Config:
+    """Initializes .fmu at 'path' and returns its configuration."""
+    path = fmu_dir_path.path
+    try:
+        fmu_dir = init_fmu_directory(path)
+        return fmu_dir.config.load()
+    except PermissionError as e:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Permission denied creating .fmu at {path}",
+        ) from e
+    except FileNotFoundError as e:
+        raise HTTPException(
+            status_code=404, detail=f"Path {path} does not exist"
+        ) from e
+    except FileExistsError as e:
+        raise HTTPException(
+            status_code=409, detail=f".fmu already exists at {path}"
+        ) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @api_v1_router.get("/health")

--- a/tests/test_api/test_api_v1_main.py
+++ b/tests/test_api/test_api_v1_main.py
@@ -1,7 +1,13 @@
 """Tests the root routes of /api/v1."""
 
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
 from fastapi import status
 from fastapi.testclient import TestClient
+from fmu.settings._init import init_fmu_directory
+from fmu.settings.resources.config import Config
 
 from fmu_settings_api.__main__ import app
 from fmu_settings_api.config import settings
@@ -31,3 +37,154 @@ def test_health_check_valid_token(mock_token: str) -> None:
     )
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"status": "ok"}
+
+
+def test_get_fmu_directory_no_permissions(mock_token: str, tmp_path: Path) -> None:
+    """Test 403 returns when lacking permissions to path."""
+    path = tmp_path / "foo"
+    path.mkdir()
+    path.chmod(stat.S_IRUSR)
+
+    response = client.post(
+        "/api/v1/fmu",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(path)},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {"detail": f"Permission denied accessing .fmu at {path}"}
+
+
+def test_get_fmu_directory_does_not_exist(mock_token: str) -> None:
+    """Test 404 returns when .fmu or directory does not exist."""
+    path = "/dev/null"
+    response = client.post(
+        "/api/v1/fmu",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": path},
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": f"No .fmu directory found at {path}"}
+
+
+def test_get_fmu_directory_is_not_directory(mock_token: str, tmp_path: Path) -> None:
+    """Test 409 returns when .fmu exists but is not a directory."""
+    path = tmp_path / ".fmu"
+    path.touch()
+
+    response = client.post(
+        "/api/v1/fmu",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json() == {
+        "detail": f".fmu exists at {tmp_path} but is not a directory"
+    }
+
+
+def test_get_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
+    """Test 500 returns if other exceptions are raised."""
+    with patch(
+        "fmu_settings_api.v1.main.get_fmu_directory", side_effect=Exception("foo")
+    ):
+        path = "/dev/null"
+        response = client.post(
+            "/api/v1/fmu",
+            headers={settings.TOKEN_HEADER_NAME: mock_token},
+            json={"path": path},
+        )
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json() == {"detail": "foo"}
+
+
+def test_get_fmu_directory_exists(mock_token: str, tmp_path: Path) -> None:
+    """Test 200 and config returns when .fmu exists."""
+    fmu_dir = init_fmu_directory(tmp_path)
+
+    response = client.post(
+        "/api/v1/fmu",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    config = Config.model_validate(response.json())
+    assert fmu_dir.config.load() == config
+
+
+def test_init_fmu_directory_no_permissions(mock_token: str, tmp_path: Path) -> None:
+    """Test 403 returns when lacking permissions to path."""
+    path = tmp_path / "foo"
+    path.mkdir()
+    path.chmod(stat.S_IRUSR)
+
+    response = client.post(
+        "/api/v1/fmu/init",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(path)},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {"detail": f"Permission denied creating .fmu at {path}"}
+
+
+def test_init_fmu_directory_does_not_exist(mock_token: str) -> None:
+    """Test 404 returns when directory to initialize .fmu does not exist."""
+    path = "/dev/null/foo"
+    response = client.post(
+        "/api/v1/fmu/init",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": path},
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": f"Path {path} does not exist"}
+
+
+def test_init_fmu_directory_is_not_directory(mock_token: str, tmp_path: Path) -> None:
+    """Test 409 returns when .fmu exists already at a path."""
+    path = tmp_path / ".fmu"
+    path.mkdir()
+
+    response = client.post(
+        "/api/v1/fmu/init",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json() == {"detail": f".fmu already exists at {tmp_path}"}
+
+
+def test_init_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
+    """Test 500 returns if other exceptions are raised."""
+    with patch(
+        "fmu_settings_api.v1.main.init_fmu_directory", side_effect=Exception("foo")
+    ):
+        path = "/dev/null"
+        response = client.post(
+            "/api/v1/fmu/init",
+            headers={settings.TOKEN_HEADER_NAME: mock_token},
+            json={"path": path},
+        )
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json() == {"detail": "foo"}
+
+
+def test_init_and_get_fmu_directory_succeeds(mock_token: str, tmp_path: Path) -> None:
+    """Test 200 and config returns when .fmu exists."""
+    init_response = client.post(
+        "/api/v1/fmu/init",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert init_response.status_code == status.HTTP_200_OK
+    init_config = Config.model_validate(init_response.json())
+    assert (tmp_path / ".fmu").exists()
+    assert (tmp_path / ".fmu").is_dir()
+    assert (tmp_path / ".fmu/config.json").exists()
+
+    get_response = client.post(
+        "/api/v1/fmu",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert get_response.status_code == status.HTTP_200_OK
+    get_config = Config.model_validate(get_response.json())
+    assert init_config == get_config


### PR DESCRIPTION
Resolves #8

- POST `api/v1/fmu` with a `path` -> whether or not .fmu exists there. If it does, returns the config.
- POST `api/v1/fmu/init` creates .fmu at `path` and returns the config.

Following step will be to have the _success_ of either of these to create a session

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
