### PR TITLE
ENH: Add fmu directory sessions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "httpx",
     "mypy",
     "pytest",
+    "pytest-asyncio",
     "pytest-cov",
     "pytest-mock",
     "pytest-xdist",
@@ -83,6 +84,8 @@ norecursedirs = [
 markers = [
     "integration: Marks a test as an integration test",
 ]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 line-length = 88

--- a/src/fmu_settings_api/config.py
+++ b/src/fmu_settings_api/config.py
@@ -27,6 +27,8 @@ class APISettings(BaseModel):
 
     API_V1_PREFIX: str = Field(default="/api/v1", frozen=True)
     TOKEN_HEADER_NAME: str = Field(default="x-fmu-settings-api", frozen=True)
+    SESSION_COOKIE_KEY: str = Field(default="fmu_settings_session", frozen=True)
+    SESSION_EXPIRE_SECONDS: int = Field(default=3600, frozen=True)
     DOMAIN: str = "localhost"
     TOKEN: str = Field(
         default_factory=generate_auth_token, pattern=r"^[a-fA-F0-9]{64}$"

--- a/src/fmu_settings_api/deps.py
+++ b/src/fmu_settings_api/deps.py
@@ -2,18 +2,45 @@
 
 from typing import Annotated
 
-from fastapi import HTTPException, Security
+from fastapi import Cookie, Depends, HTTPException, Security
 from fastapi.security import APIKeyHeader
 
 from fmu_settings_api.config import settings
+from fmu_settings_api.session import Session, session_manager
 
 api_token_header = APIKeyHeader(name=settings.TOKEN_HEADER_NAME)
 
 TokenHeaderDep = Annotated[str, Security(api_token_header)]
 
 
-def verify_auth_token(req_token: TokenHeaderDep) -> TokenHeaderDep:
+async def verify_auth_token(req_token: TokenHeaderDep) -> TokenHeaderDep:
     """Verifies the request token vs the stored one."""
     if req_token != settings.TOKEN:
         raise HTTPException(status_code=401, detail="Not authorized")
     return req_token
+
+
+async def get_fmu_session(fmu_settings_session: str | None = Cookie(None)) -> Session:
+    """Gets a session from the session manager."""
+    if not fmu_settings_session:
+        raise HTTPException(
+            status_code=401,
+            detail="No active session found",
+            headers={"WWW-Authenticate": "Cookie-Auth"},
+        )
+    try:
+        session = await session_manager.get_session(fmu_settings_session)
+        if not session:
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid or expired session",
+                headers={"WWW-Authenticate": "Cookie-Auth"},
+            )
+        return session
+    except Exception as e:
+        if isinstance(e, HTTPException):
+            raise
+        raise HTTPException(status_code=500, detail=f"Session error: {e}") from e
+
+
+SessionDep = Annotated[Session, Depends(get_fmu_session)]

--- a/src/fmu_settings_api/models/fmu.py
+++ b/src/fmu_settings_api/models/fmu.py
@@ -1,0 +1,12 @@
+"""Models pertaining to the .fmu directory."""
+
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class FMUDirPath(BaseModel):
+    """Path where a .fmu directory may exist."""
+
+    path: Path
+    """Path to the directory which should or will contain a .fmu directory."""

--- a/src/fmu_settings_api/session.py
+++ b/src/fmu_settings_api/session.py
@@ -1,0 +1,106 @@
+"""Functionality for managing sessions."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Self
+from uuid import uuid4
+
+from fmu.settings import FMUDirectory
+
+from fmu_settings_api.config import settings
+
+
+@dataclass
+class Session:
+    """Represents session information when working on an FMU Directory."""
+
+    fmu_directory: FMUDirectory
+    created_at: datetime
+    expires_at: datetime
+    last_accessed: datetime
+
+
+class SessionManager:
+    """Manages sessions started when an FMU Directory as been opened.
+
+    A better implementation would involve creating a storage backend interface that all
+    backends implement. Because our use case is simple only hints of this are here and
+    it simply uses a dictionary backend.
+    """
+
+    Storage = dict[str, Session]
+    """Type alias for the storage backend instance."""
+
+    storage: Storage
+    """Instances of the storage backend."""
+
+    def __init__(self: Self) -> None:
+        """Initializes the session manager singleton."""
+        self.storage = {}
+
+    async def _store_session(self: Self, session_id: str, session: Session) -> None:
+        """Stores a newly created session."""
+        self.storage[session_id] = session
+
+    async def _retrieve_session(self: Self, session_id: str) -> Session | None:
+        """Retrieves a session from the storage backend."""
+        return self.storage.get(session_id, None)
+
+    async def _update_session(self: Self, session_id: str, session: Session) -> None:
+        """Stores an updated session back into the session backend."""
+        self.storage[session_id] = session
+
+    async def destroy_session(self: Self, session_id: str) -> None:
+        """Destroys a session by its session id."""
+        del self.storage[session_id]
+
+    async def create_session(
+        self: Self,
+        fmu_directory: FMUDirectory,
+        expire_seconds: int = settings.SESSION_EXPIRE_SECONDS,
+    ) -> str:
+        """Creates a new session and stores it to the storage backend."""
+        session_id = str(uuid4())
+        now = datetime.now(UTC)
+        expiration_duration = timedelta(seconds=expire_seconds)
+
+        session = Session(
+            fmu_directory=fmu_directory,
+            created_at=now,
+            expires_at=now + expiration_duration,
+            last_accessed=now,
+        )
+        await self._store_session(session_id, session)
+
+        return session_id
+
+    async def get_session(self: Self, session_id: str) -> Session | None:
+        """Get the session data for a session id."""
+        session = await self._retrieve_session(session_id)
+        if not session:
+            return None
+
+        now = datetime.now(UTC)
+        if session.expires_at < now:
+            await self.destroy_session(session_id)
+            return None
+
+        session.last_accessed = now
+        await self._update_session(session_id, session)
+        return session
+
+
+session_manager = SessionManager()
+
+
+async def create_fmu_session(
+    fmu_directory: FMUDirectory,
+    expire_seconds: int = settings.SESSION_EXPIRE_SECONDS,
+) -> str:
+    """Creates a new session and stores it in the session mananger."""
+    return await session_manager.create_session(fmu_directory, expire_seconds)
+
+
+async def destroy_fmu_session(session_id: str) -> None:
+    """Destroys a session in the session manager."""
+    await session_manager.destroy_session(session_id)

--- a/src/fmu_settings_api/v1/main.py
+++ b/src/fmu_settings_api/v1/main.py
@@ -1,76 +1,19 @@
 """The main router for /api/v1."""
 
-from pathlib import Path
-
-from fastapi import APIRouter, Depends, HTTPException
-from fmu.settings import get_fmu_directory
-from fmu.settings._init import init_fmu_directory
-from fmu.settings.resources.config import Config
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends
 
 from fmu_settings_api.config import settings
 from fmu_settings_api.deps import verify_auth_token
+
+from .routes import config, fmu
 
 api_v1_router = APIRouter(
     prefix=settings.API_V1_PREFIX,
     tags=["v1"],
     dependencies=[Depends(verify_auth_token)],
 )
-
-
-class FMUDirPath(BaseModel):
-    """Path where a .fmu directory may exist."""
-
-    path: Path
-    """Path to the directory which should or will contain a .fmu directory."""
-
-
-@api_v1_router.post("/fmu")
-async def get_fmu_directory_session(fmu_dir_path: FMUDirPath) -> Config:
-    """Returns the configuration for the .fmu directory at 'path'."""
-    path = fmu_dir_path.path
-    try:
-        fmu_dir = get_fmu_directory(path)
-        return fmu_dir.config.load()
-    except PermissionError as e:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Permission denied accessing .fmu at {path}",
-        ) from e
-    except FileNotFoundError as e:
-        raise HTTPException(
-            status_code=404, detail=f"No .fmu directory found at {path}"
-        ) from e
-    except FileExistsError as e:
-        raise HTTPException(
-            status_code=409, detail=f".fmu exists at {path} but is not a directory"
-        ) from e
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
-
-
-@api_v1_router.post("/fmu/init")
-async def init_fmu_directory_session(fmu_dir_path: FMUDirPath) -> Config:
-    """Initializes .fmu at 'path' and returns its configuration."""
-    path = fmu_dir_path.path
-    try:
-        fmu_dir = init_fmu_directory(path)
-        return fmu_dir.config.load()
-    except PermissionError as e:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Permission denied creating .fmu at {path}",
-        ) from e
-    except FileNotFoundError as e:
-        raise HTTPException(
-            status_code=404, detail=f"Path {path} does not exist"
-        ) from e
-    except FileExistsError as e:
-        raise HTTPException(
-            status_code=409, detail=f".fmu already exists at {path}"
-        ) from e
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+api_v1_router.include_router(fmu.router)
+api_v1_router.include_router(config.router)
 
 
 @api_v1_router.get("/health")

--- a/src/fmu_settings_api/v1/routes/__init__.py
+++ b/src/fmu_settings_api/v1/routes/__init__.py
@@ -1,0 +1,1 @@
+"""Modules mapping to the routes of /api/v1."""

--- a/src/fmu_settings_api/v1/routes/config.py
+++ b/src/fmu_settings_api/v1/routes/config.py
@@ -1,0 +1,27 @@
+"""Routes to operate on the .fmu config file."""
+
+from fastapi import APIRouter, HTTPException
+from fmu.settings.resources.config import Config
+
+from fmu_settings_api.deps import SessionDep
+
+router = APIRouter(prefix="/config", tags=["config"])
+
+
+@router.get("/", response_model=Config)
+async def get_fmu_directory_config(session: SessionDep) -> Config:
+    """Returns the configuration for the currently open FMU Directory session."""
+    try:
+        config = session.fmu_directory.config
+        return config.load()
+    except PermissionError as e:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Permission denied loading .fmu config at {config.path}",
+        ) from e
+    except FileNotFoundError as e:
+        raise HTTPException(
+            status_code=404, detail=f".fmu config at {config.path} does not exist"
+        ) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,18 @@
 """Root configuration for pytest."""
 
+import stat
+from collections.abc import AsyncGenerator, Generator
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
+from fastapi.testclient import TestClient
+from fmu.settings import FMUDirectory
+from fmu.settings._init import init_fmu_directory
+
+from fmu_settings_api.__main__ import app
+from fmu_settings_api.config import settings
+from fmu_settings_api.session import SessionManager
 
 
 @pytest.fixture
@@ -11,3 +23,45 @@ def mock_token() -> str:
     token = "safe" * 16
     settings.TOKEN = token
     return token
+
+
+@pytest.fixture
+def fmu_dir(tmp_path: Path) -> FMUDirectory:
+    """Creates a .fmu directory in a tmp path."""
+    return init_fmu_directory(tmp_path)
+
+
+@pytest.fixture
+def fmu_dir_path(fmu_dir: FMUDirectory) -> Path:
+    """Returns the tmp path of a .fmu directory."""
+    return fmu_dir.base_path
+
+
+@pytest.fixture
+def fmu_dir_no_permissions(fmu_dir_path: Path) -> Path:
+    """Mocks a .fmu in a tmp_path without permissions."""
+    (fmu_dir_path / ".fmu").chmod(stat.S_IRUSR)
+    return fmu_dir_path
+
+
+@pytest.fixture
+def session_manager() -> Generator[SessionManager]:
+    """Mocks the session manager and returns its replacement."""
+    session_manager = SessionManager()
+    with patch("fmu_settings_api.deps.session_manager", session_manager):
+        yield session_manager
+
+
+@pytest.fixture
+async def session_id(tmp_path: Path, session_manager: SessionManager) -> str:
+    """Mocks a valid opened .fmu session."""
+    fmu_dir = init_fmu_directory(tmp_path)
+    return await session_manager.create_session(fmu_dir)
+
+
+@pytest.fixture
+async def client_with_session(session_id: str) -> AsyncGenerator[TestClient]:
+    """Returns a test client with a valid session."""
+    with TestClient(app) as c:
+        c.cookies[settings.SESSION_COOKIE_KEY] = session_id
+        yield c

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,99 @@
+"""Tests the SessionManager functionality."""
+
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from fmu.settings import FMUDirectory
+
+from fmu_settings_api.config import settings
+from fmu_settings_api.session import (
+    SessionManager,
+    create_fmu_session,
+    destroy_fmu_session,
+    session_manager,
+)
+
+
+def test_session_manager_init() -> None:
+    """Tests initialization of the SessionManager."""
+    assert session_manager.storage == SessionManager().storage == {}
+
+
+async def test_create_session(
+    session_manager: SessionManager, fmu_dir: FMUDirectory
+) -> None:
+    """Tests creating a new session."""
+    session_id = await session_manager.create_session(fmu_dir)
+    assert session_id in session_manager.storage
+    assert session_manager.storage[session_id].fmu_directory == fmu_dir
+    assert len(session_manager.storage) == 1
+
+
+async def test_create_session_wrapper(
+    session_manager: SessionManager, fmu_dir: FMUDirectory
+) -> None:
+    """Tests creating a new session with the wrapper."""
+    with patch("fmu_settings_api.session.session_manager", session_manager):
+        session_id = await create_fmu_session(fmu_dir)
+    assert session_id in session_manager.storage
+    assert session_manager.storage[session_id].fmu_directory == fmu_dir
+    assert len(session_manager.storage) == 1
+
+
+async def test_get_non_existing_session(
+    session_manager: SessionManager, fmu_dir: FMUDirectory
+) -> None:
+    """Tests getting an existing session."""
+    await session_manager.create_session(fmu_dir)
+    assert await session_manager.get_session("no") is None
+    assert len(session_manager.storage) == 1
+
+
+async def test_get_existing_session(
+    session_manager: SessionManager, fmu_dir: FMUDirectory
+) -> None:
+    """Tests getting an existing session."""
+    session_id = await session_manager.create_session(fmu_dir)
+    session = await session_manager.get_session(session_id)
+    assert session == session_manager.storage[session_id]
+    assert len(session_manager.storage) == 1
+
+
+async def test_get_existing_session_expiration(
+    session_manager: SessionManager, fmu_dir: FMUDirectory
+) -> None:
+    """Tests getting an existing session expires."""
+    session_id = await session_manager.create_session(fmu_dir)
+    orig_session = session_manager.storage[session_id]
+    expiration_duration = timedelta(seconds=settings.SESSION_EXPIRE_SECONDS)
+    assert orig_session.created_at + expiration_duration == orig_session.expires_at
+
+    # Pretend it expired a second ago.
+    orig_session.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    assert await session_manager.get_session(session_id) is None
+    # It should also be destroyed.
+    assert session_id not in session_manager.storage
+    assert len(session_manager.storage) == 0
+
+
+async def test_get_existing_session_updates_last_accessed(
+    session_manager: SessionManager, fmu_dir: FMUDirectory
+) -> None:
+    """Tests getting an existing session updates its last accessed."""
+    session_id = await session_manager.create_session(fmu_dir)
+    orig_session = deepcopy(session_manager.storage[session_id])
+    session = await session_manager.get_session(session_id)
+    assert session is not None
+    assert orig_session.last_accessed < session.last_accessed
+
+
+async def test_destroy_fmu_session(
+    session_manager: SessionManager, fmu_dir: FMUDirectory
+) -> None:
+    """Tests destroying a session."""
+    session_id = await session_manager.create_session(fmu_dir)
+    with patch("fmu_settings_api.session.session_manager", session_manager):
+        await destroy_fmu_session(session_id)
+    assert session_id not in session_manager.storage
+    assert len(session_manager.storage) == 0

--- a/tests/test_v1/test_config.py
+++ b/tests/test_v1/test_config.py
@@ -1,0 +1,113 @@
+"""Tests the /api/v1/config routes."""
+
+import stat
+from unittest.mock import patch
+
+from fastapi import status
+from fastapi.testclient import TestClient
+from fmu.settings.resources.config import Config, ConfigManager
+
+from fmu_settings_api.__main__ import app
+from fmu_settings_api.config import settings
+from fmu_settings_api.deps import get_fmu_session
+
+client = TestClient(app)
+
+ROUTE = "/api/v1/config"
+
+
+def test_get_config_unauthorized() -> None:
+    """Test that the config routes requires an auth token."""
+    response = client.get(ROUTE, headers={})
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_get_config_invalid_token() -> None:
+    """Tests the config routes requires a valid token."""
+    token = "no" * 32
+    response = client.get(ROUTE, headers={settings.TOKEN_HEADER_NAME: token})
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "Not authorized"}
+
+
+def test_get_config_no_session(mock_token: str) -> None:
+    """Tests the config routes requires a session."""
+    response = client.get(ROUTE, headers={settings.TOKEN_HEADER_NAME: mock_token})
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "No active session found"}
+
+
+async def test_get_config_with_session(
+    mock_token: str, client_with_session: TestClient
+) -> None:
+    """Tests the config is return with a valid session."""
+    response = client_with_session.get(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert Config.model_validate(response.json())
+
+
+async def test_get_config_with_session_without_permissions(
+    mock_token: str, client_with_session: TestClient
+) -> None:
+    """Tests the config is return with a valid session, but no config."""
+    cookie_session_id = client_with_session.cookies.get(settings.SESSION_COOKIE_KEY)
+    assert cookie_session_id is not None
+    session = await get_fmu_session(cookie_session_id)
+
+    # Clear the cache first.
+    session.fmu_directory.config._cache = None
+    fmu_path = session.fmu_directory.path
+    fmu_path.chmod(stat.S_IRUSR)
+
+    config_path = session.fmu_directory.config.path
+
+    response = client_with_session.get(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {
+        "detail": f"Permission denied loading .fmu config at {config_path}"
+    }
+
+
+async def test_get_config_with_session_but_config_not_found(
+    mock_token: str, client_with_session: TestClient
+) -> None:
+    """Tests the config is return with a valid session, but no config."""
+    cookie_session_id = client_with_session.cookies.get(settings.SESSION_COOKIE_KEY)
+    assert cookie_session_id is not None
+    session = await get_fmu_session(cookie_session_id)
+
+    # Pretend the config/config cache doesn't exist
+    session.fmu_directory.config._cache = None
+    config_path = session.fmu_directory.config.path
+    config_path.unlink()
+
+    response = client_with_session.get(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": f".fmu config at {config_path} does not exist"}
+
+
+async def test_get_config_with_session_unknown_error(
+    mock_token: str, client_with_session: TestClient
+) -> None:
+    """Test 500 returns if other exceptions are raised."""
+    with patch.object(
+        ConfigManager,
+        "load",
+        side_effect=Exception("foo"),
+    ):
+        response = client_with_session.get(
+            ROUTE,
+            headers={settings.TOKEN_HEADER_NAME: mock_token},
+        )
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json() == {"detail": "foo"}

--- a/tests/test_v1/test_fmu.py
+++ b/tests/test_v1/test_fmu.py
@@ -1,4 +1,4 @@
-"""Tests the root routes of /api/v1."""
+"""Tests the /api/v1/fmu routes."""
 
 import stat
 from pathlib import Path
@@ -14,51 +14,44 @@ from fmu_settings_api.config import settings
 
 client = TestClient(app)
 
+ROUTE = "/api/v1/fmu"
 
-def test_health_check_unauthorized() -> None:
-    """Test the health check endpoint with missing token."""
-    response = client.get("/api/v1/health", headers={})
+
+def test_get_fmu_unauthorized() -> None:
+    """Tests the fmu routes requires a token."""
+    response = client.post(ROUTE, headers={})
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.json() == {"detail": "Not authenticated"}
 
 
-def test_health_check_invalid_token() -> None:
-    """Test the health check endpoint with an invalid token."""
+def test_get_fmu_invalid_token() -> None:
+    """Tests the fmu routes requires a valid token."""
     token = "no" * 32
-    response = client.get("/api/v1/health", headers={settings.TOKEN_HEADER_NAME: token})
+    response = client.post(ROUTE, headers={settings.TOKEN_HEADER_NAME: token})
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "Not authorized"}
 
 
-def test_health_check_valid_token(mock_token: str) -> None:
-    """Test the health check endpoint with a valid token."""
-    response = client.get(
-        "/api/v1/health", headers={settings.TOKEN_HEADER_NAME: mock_token}
-    )
-    assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {"status": "ok"}
-
-
-def test_get_fmu_directory_no_permissions(mock_token: str, tmp_path: Path) -> None:
+def test_get_fmu_directory_no_permissions(
+    mock_token: str, fmu_dir_no_permissions: Path
+) -> None:
     """Test 403 returns when lacking permissions to path."""
-    path = tmp_path / "foo"
-    path.mkdir()
-    path.chmod(stat.S_IRUSR)
-
     response = client.post(
-        "/api/v1/fmu",
+        ROUTE,
         headers={settings.TOKEN_HEADER_NAME: mock_token},
-        json={"path": str(path)},
+        json={"path": str(fmu_dir_no_permissions)},
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
-    assert response.json() == {"detail": f"Permission denied accessing .fmu at {path}"}
+    assert response.json() == {
+        "detail": f"Permission denied accessing .fmu at {fmu_dir_no_permissions}"
+    }
 
 
 def test_get_fmu_directory_does_not_exist(mock_token: str) -> None:
     """Test 404 returns when .fmu or directory does not exist."""
     path = "/dev/null"
     response = client.post(
-        "/api/v1/fmu",
+        ROUTE,
         headers={settings.TOKEN_HEADER_NAME: mock_token},
         json={"path": path},
     )
@@ -72,7 +65,7 @@ def test_get_fmu_directory_is_not_directory(mock_token: str, tmp_path: Path) -> 
     path.touch()
 
     response = client.post(
-        "/api/v1/fmu",
+        ROUTE,
         headers={settings.TOKEN_HEADER_NAME: mock_token},
         json={"path": str(tmp_path)},
     )
@@ -85,11 +78,11 @@ def test_get_fmu_directory_is_not_directory(mock_token: str, tmp_path: Path) -> 
 def test_get_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
     """Test 500 returns if other exceptions are raised."""
     with patch(
-        "fmu_settings_api.v1.main.get_fmu_directory", side_effect=Exception("foo")
+        "fmu_settings_api.v1.routes.fmu.get_fmu_directory", side_effect=Exception("foo")
     ):
         path = "/dev/null"
         response = client.post(
-            "/api/v1/fmu",
+            ROUTE,
             headers={settings.TOKEN_HEADER_NAME: mock_token},
             json={"path": path},
         )
@@ -102,7 +95,7 @@ def test_get_fmu_directory_exists(mock_token: str, tmp_path: Path) -> None:
     fmu_dir = init_fmu_directory(tmp_path)
 
     response = client.post(
-        "/api/v1/fmu",
+        ROUTE,
         headers={settings.TOKEN_HEADER_NAME: mock_token},
         json={"path": str(tmp_path)},
     )
@@ -118,7 +111,7 @@ def test_init_fmu_directory_no_permissions(mock_token: str, tmp_path: Path) -> N
     path.chmod(stat.S_IRUSR)
 
     response = client.post(
-        "/api/v1/fmu/init",
+        f"{ROUTE}/init",
         headers={settings.TOKEN_HEADER_NAME: mock_token},
         json={"path": str(path)},
     )
@@ -130,7 +123,7 @@ def test_init_fmu_directory_does_not_exist(mock_token: str) -> None:
     """Test 404 returns when directory to initialize .fmu does not exist."""
     path = "/dev/null/foo"
     response = client.post(
-        "/api/v1/fmu/init",
+        f"{ROUTE}/init",
         headers={settings.TOKEN_HEADER_NAME: mock_token},
         json={"path": path},
     )
@@ -138,13 +131,27 @@ def test_init_fmu_directory_does_not_exist(mock_token: str) -> None:
     assert response.json() == {"detail": f"Path {path} does not exist"}
 
 
-def test_init_fmu_directory_is_not_directory(mock_token: str, tmp_path: Path) -> None:
+def test_init_fmu_directory_is_not_a_directory(mock_token: str, tmp_path: Path) -> None:
+    """Test 409 returns when .fmu exists as a file at a path."""
+    path = tmp_path / ".fmu"
+    path.touch()
+
+    response = client.post(
+        f"{ROUTE}/init",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json() == {"detail": f".fmu already exists at {tmp_path}"}
+
+
+def test_init_fmu_directory_already_exists(mock_token: str, tmp_path: Path) -> None:
     """Test 409 returns when .fmu exists already at a path."""
     path = tmp_path / ".fmu"
     path.mkdir()
 
     response = client.post(
-        "/api/v1/fmu/init",
+        f"{ROUTE}/init",
         headers={settings.TOKEN_HEADER_NAME: mock_token},
         json={"path": str(tmp_path)},
     )
@@ -155,11 +162,12 @@ def test_init_fmu_directory_is_not_directory(mock_token: str, tmp_path: Path) ->
 def test_init_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
     """Test 500 returns if other exceptions are raised."""
     with patch(
-        "fmu_settings_api.v1.main.init_fmu_directory", side_effect=Exception("foo")
+        "fmu_settings_api.v1.routes.fmu.init_fmu_directory",
+        side_effect=Exception("foo"),
     ):
         path = "/dev/null"
         response = client.post(
-            "/api/v1/fmu/init",
+            f"{ROUTE}/init",
             headers={settings.TOKEN_HEADER_NAME: mock_token},
             json={"path": path},
         )
@@ -170,7 +178,7 @@ def test_init_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
 def test_init_and_get_fmu_directory_succeeds(mock_token: str, tmp_path: Path) -> None:
     """Test 200 and config returns when .fmu exists."""
     init_response = client.post(
-        "/api/v1/fmu/init",
+        f"{ROUTE}/init",
         headers={settings.TOKEN_HEADER_NAME: mock_token},
         json={"path": str(tmp_path)},
     )
@@ -181,7 +189,7 @@ def test_init_and_get_fmu_directory_succeeds(mock_token: str, tmp_path: Path) ->
     assert (tmp_path / ".fmu/config.json").exists()
 
     get_response = client.post(
-        "/api/v1/fmu",
+        ROUTE,
         headers={settings.TOKEN_HEADER_NAME: mock_token},
         json={"path": str(tmp_path)},
     )

--- a/tests/test_v1/test_health.py
+++ b/tests/test_v1/test_health.py
@@ -1,0 +1,33 @@
+"""Tests the root routes of /api/v1."""
+
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from fmu_settings_api.__main__ import app
+from fmu_settings_api.config import settings
+
+client = TestClient(app)
+
+ROUTE = "/api/v1/health"
+
+
+def test_health_check_unauthorized() -> None:
+    """Test the health check endpoint with missing token."""
+    response = client.get(ROUTE, headers={})
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_health_check_invalid_token() -> None:
+    """Test the health check endpoint with an invalid token."""
+    token = "no" * 32
+    response = client.get(ROUTE, headers={settings.TOKEN_HEADER_NAME: token})
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "Not authorized"}
+
+
+def test_health_check_valid_token(mock_token: str) -> None:
+    """Test the health check endpoint with a valid token."""
+    response = client.get(ROUTE, headers={settings.TOKEN_HEADER_NAME: mock_token})
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
Resolves #11
Resolves #7

PR to manage sessions when an FMU Directory has been "opened".

- When an FMU directory is initialize or be opened with a 'get', a session is created
- The session is just a random UUID cookie that makes to an internal, very basic session store
- This store is just a Python dictionary in memory which contains the `FMUDirectory()` instance
- Routes that operate on resources within the .fmu directory depend on this session
- They will return 401 if a valid session cookie is not sent with the requires
- They have an expiration date of one hour (i.e., if no requests have occurred for one hour)
- The expiration date is adjusted with every validated request
- Eventually, fmu.settings (or this api) will need to apply a lock when working in .fmu, so the expiration will (eventually) prevent persistent locks

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
