### PR TITLE
ENH: Add '/fmu' GET route

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,10 +38,11 @@ def fmu_dir_path(fmu_dir: FMUDirectory) -> Path:
 
 
 @pytest.fixture
-def fmu_dir_no_permissions(fmu_dir_path: Path) -> Path:
+def fmu_dir_no_permissions(fmu_dir_path: Path) -> Generator[Path, None, None]:
     """Mocks a .fmu in a tmp_path without permissions."""
     (fmu_dir_path / ".fmu").chmod(stat.S_IRUSR)
-    return fmu_dir_path
+    yield fmu_dir_path
+    (fmu_dir_path / ".fmu").chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
 
 @pytest.fixture


### PR DESCRIPTION
Resolves #18

The `/fmu` `GET` route searches for the nearest directory, while the `POST` to the same endpoint accepts a path to check. It will initialize a session if one is found.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
