### PR TITLE
ENH: Add 'DELETE' session route

### DIFF
--- a/src/fmu_settings_api/models/__init__.py
+++ b/src/fmu_settings_api/models/__init__.py
@@ -1,0 +1,6 @@
+"""Models used for messages and responses at API endpoints."""
+
+from .common import Message
+from .fmu import FMUDirPath
+
+__all__ = ["FMUDirPath", "Message"]

--- a/src/fmu_settings_api/models/common.py
+++ b/src/fmu_settings_api/models/common.py
@@ -1,0 +1,9 @@
+"""Common response models from the API."""
+
+from pydantic import BaseModel
+
+
+class Message(BaseModel):
+    """A generic message to return to the GUI."""
+
+    message: str

--- a/src/fmu_settings_api/session.py
+++ b/src/fmu_settings_api/session.py
@@ -14,6 +14,7 @@ from fmu_settings_api.config import settings
 class Session:
     """Represents session information when working on an FMU Directory."""
 
+    id: str
     fmu_directory: FMUDirectory
     created_at: datetime
     expires_at: datetime
@@ -52,7 +53,9 @@ class SessionManager:
 
     async def destroy_session(self: Self, session_id: str) -> None:
         """Destroys a session by its session id."""
-        del self.storage[session_id]
+        session = await self._retrieve_session(session_id)
+        if session is not None:
+            del self.storage[session_id]
 
     async def create_session(
         self: Self,
@@ -65,6 +68,7 @@ class SessionManager:
         expiration_duration = timedelta(seconds=expire_seconds)
 
         session = Session(
+            id=session_id,
             fmu_directory=fmu_directory,
             created_at=now,
             expires_at=now + expiration_duration,

--- a/tests/test_v1/test_fmu.py
+++ b/tests/test_v1/test_fmu.py
@@ -33,6 +33,9 @@ def test_get_fmu_invalid_token() -> None:
     assert response.json() == {"detail": "Not authorized"}
 
 
+# GET fmu/ #
+
+
 def test_get_cwd_fmu_directory_no_permissions(
     mock_token: str, fmu_dir_no_permissions: Path, monkeypatch: MonkeyPatch
 ) -> None:
@@ -121,7 +124,34 @@ def test_get_cwd_fmu_directory_exists(
     assert fmu_dir.config.load() == config
 
 
-def test_get_fmu_directory_no_permissions(
+async def test_get_fmu_directory_sets_session_cookie(
+    mock_token: str, tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests that getting an FMU Directory sets a correct session cookie."""
+    fmu_dir = init_fmu_directory(tmp_path)
+    ert_model_path = tmp_path / "project/24.0.3/ert/model"
+    ert_model_path.mkdir(parents=True)
+    monkeypatch.chdir(ert_model_path)
+
+    response = client.get(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    session_id = response.cookies.get(settings.SESSION_COOKIE_KEY, None)
+    assert session_id is not None
+
+    from fmu_settings_api.session import session_manager
+
+    session = await session_manager.get_session(session_id)
+    assert session is not None
+    assert session.fmu_directory.path == fmu_dir.path
+
+
+# POST fmu/ #
+
+
+def test_post_fmu_directory_no_permissions(
     mock_token: str, fmu_dir_no_permissions: Path
 ) -> None:
     """Test 403 returns when lacking permissions to path."""
@@ -134,9 +164,10 @@ def test_get_fmu_directory_no_permissions(
     assert response.json() == {
         "detail": f"Permission denied accessing .fmu at {fmu_dir_no_permissions}"
     }
+    assert settings.SESSION_COOKIE_KEY not in response.cookies
 
 
-def test_get_fmu_directory_does_not_exist(mock_token: str) -> None:
+def test_post_fmu_directory_does_not_exist(mock_token: str) -> None:
     """Test 404 returns when .fmu or directory does not exist."""
     path = "/dev/null"
     response = client.post(
@@ -146,9 +177,10 @@ def test_get_fmu_directory_does_not_exist(mock_token: str) -> None:
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.json() == {"detail": f"No .fmu directory found at {path}"}
+    assert settings.SESSION_COOKIE_KEY not in response.cookies
 
 
-def test_get_fmu_directory_is_not_directory(mock_token: str, tmp_path: Path) -> None:
+def test_post_fmu_directory_is_not_directory(mock_token: str, tmp_path: Path) -> None:
     """Test 409 returns when .fmu exists but is not a directory."""
     path = tmp_path / ".fmu"
     path.touch()
@@ -162,9 +194,10 @@ def test_get_fmu_directory_is_not_directory(mock_token: str, tmp_path: Path) -> 
     assert response.json() == {
         "detail": f".fmu exists at {tmp_path} but is not a directory"
     }
+    assert settings.SESSION_COOKIE_KEY not in response.cookies
 
 
-def test_get_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
+def test_post_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
     """Test 500 returns if other exceptions are raised."""
     with patch(
         "fmu_settings_api.v1.routes.fmu.get_fmu_directory", side_effect=Exception("foo")
@@ -177,9 +210,10 @@ def test_get_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
         )
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert response.json() == {"detail": "foo"}
+        assert settings.SESSION_COOKIE_KEY not in response.cookies
 
 
-def test_get_fmu_directory_exists(mock_token: str, tmp_path: Path) -> None:
+def test_post_fmu_directory_exists(mock_token: str, tmp_path: Path) -> None:
     """Test 200 and config returns when .fmu exists."""
     fmu_dir = init_fmu_directory(tmp_path)
 
@@ -193,7 +227,74 @@ def test_get_fmu_directory_exists(mock_token: str, tmp_path: Path) -> None:
     assert fmu_dir.config.load() == config
 
 
-def test_init_fmu_directory_no_permissions(mock_token: str, tmp_path: Path) -> None:
+async def test_post_fmu_directory_sets_session_cookie(
+    mock_token: str, tmp_path: Path
+) -> None:
+    """Tests that getting an FMU Directory sets a correct session cookie."""
+    fmu_dir = init_fmu_directory(tmp_path)
+
+    response = client.post(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    session_id = response.cookies.get(settings.SESSION_COOKIE_KEY, None)
+    assert session_id is not None
+
+    from fmu_settings_api.session import session_manager
+
+    session = await session_manager.get_session(session_id)
+    assert session is not None
+    assert session.fmu_directory.path == fmu_dir.path
+
+
+# DELETE fmu/ #
+
+
+async def test_delete_fmu_directory_deletes_session_cookie(
+    mock_token: str, tmp_path: Path
+) -> None:
+    """Tests that deleting a session deletes the session cookie and session."""
+    from fmu_settings_api.session import session_manager
+
+    fmu_dir = init_fmu_directory(tmp_path)
+
+    setup_response = client.post(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert setup_response.status_code == status.HTTP_200_OK
+    session_id = setup_response.cookies.get(settings.SESSION_COOKIE_KEY, None)
+    assert session_id is not None
+    session = await session_manager.get_session(session_id)
+    assert session is not None
+    assert session.fmu_directory.path == fmu_dir.path
+
+    # Actual test below
+
+    response = client.delete(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert (
+        response.json()["message"]
+        == f"FMU directory {fmu_dir.path} closed successfully"
+    )
+    deleted_session_id = response.cookies.get(settings.SESSION_COOKIE_KEY, None)
+    assert deleted_session_id is None
+
+    session = await session_manager.get_session(session_id)
+    assert session is None
+
+
+# POST fmu/init #
+
+
+def test_post_init_fmu_directory_no_permissions(
+    mock_token: str, tmp_path: Path
+) -> None:
     """Test 403 returns when lacking permissions to path."""
     path = tmp_path / "foo"
     path.mkdir()
@@ -208,7 +309,7 @@ def test_init_fmu_directory_no_permissions(mock_token: str, tmp_path: Path) -> N
     assert response.json() == {"detail": f"Permission denied creating .fmu at {path}"}
 
 
-def test_init_fmu_directory_does_not_exist(mock_token: str) -> None:
+def test_post_init_fmu_directory_does_not_exist(mock_token: str) -> None:
     """Test 404 returns when directory to initialize .fmu does not exist."""
     path = "/dev/null/foo"
     response = client.post(
@@ -220,7 +321,9 @@ def test_init_fmu_directory_does_not_exist(mock_token: str) -> None:
     assert response.json() == {"detail": f"Path {path} does not exist"}
 
 
-def test_init_fmu_directory_is_not_a_directory(mock_token: str, tmp_path: Path) -> None:
+def test_post_init_fmu_directory_is_not_a_directory(
+    mock_token: str, tmp_path: Path
+) -> None:
     """Test 409 returns when .fmu exists as a file at a path."""
     path = tmp_path / ".fmu"
     path.touch()
@@ -234,7 +337,9 @@ def test_init_fmu_directory_is_not_a_directory(mock_token: str, tmp_path: Path) 
     assert response.json() == {"detail": f".fmu already exists at {tmp_path}"}
 
 
-def test_init_fmu_directory_already_exists(mock_token: str, tmp_path: Path) -> None:
+def test_post_init_fmu_directory_already_exists(
+    mock_token: str, tmp_path: Path
+) -> None:
     """Test 409 returns when .fmu exists already at a path."""
     path = tmp_path / ".fmu"
     path.mkdir()
@@ -248,7 +353,7 @@ def test_init_fmu_directory_already_exists(mock_token: str, tmp_path: Path) -> N
     assert response.json() == {"detail": f".fmu already exists at {tmp_path}"}
 
 
-def test_init_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
+def test_post_init_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
     """Test 500 returns if other exceptions are raised."""
     with patch(
         "fmu_settings_api.v1.routes.fmu.init_fmu_directory",
@@ -264,7 +369,9 @@ def test_init_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
         assert response.json() == {"detail": "foo"}
 
 
-def test_init_and_get_fmu_directory_succeeds(mock_token: str, tmp_path: Path) -> None:
+def test_post_init_and_get_fmu_directory_succeeds(
+    mock_token: str, tmp_path: Path
+) -> None:
     """Test 200 and config returns when .fmu exists."""
     init_response = client.post(
         f"{ROUTE}/init",
@@ -285,3 +392,23 @@ def test_init_and_get_fmu_directory_succeeds(mock_token: str, tmp_path: Path) ->
     assert get_response.status_code == status.HTTP_200_OK
     get_config = Config.model_validate(get_response.json())
     assert init_config == get_config
+
+
+async def test_post_init_succeeds_and_sets_session_cookie(
+    mock_token: str, tmp_path: Path
+) -> None:
+    """Test thats a POST fmu/init succeeds and sets a session cookie."""
+    init_response = client.post(
+        f"{ROUTE}/init",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert init_response.status_code == status.HTTP_200_OK
+    session_id = init_response.cookies.get(settings.SESSION_COOKIE_KEY, None)
+    assert session_id is not None
+
+    from fmu_settings_api.session import session_manager
+
+    session = await session_manager.get_session(session_id)
+    assert session is not None
+    assert session.fmu_directory.path == tmp_path / ".fmu"


### PR DESCRIPTION
Resolves #20 

Adds a `DELETE fmu/` route to close a session.

Another possibility is `DELETE fmu/session`. I felt that it's extremely unlikely that the API will be deleting an entire .fmu directory. That may be a mistake but... we'll see.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
