### PR TITLE
ENH: Create user .fmu dir with FMU session

### DIFF
--- a/src/fmu_settings_api/v1/routes/fmu.py
+++ b/src/fmu_settings_api/v1/routes/fmu.py
@@ -7,7 +7,7 @@ from fmu.settings import find_nearest_fmu_directory, get_fmu_directory
 from fmu.settings._init import init_fmu_directory
 
 from fmu_settings_api.config import settings
-from fmu_settings_api.deps import SessionDep
+from fmu_settings_api.deps import SessionDep, UserFMUDirDep
 from fmu_settings_api.models import FMUDirPath, FMUProject, Message
 from fmu_settings_api.session import create_fmu_session, destroy_fmu_session
 
@@ -15,7 +15,9 @@ router = APIRouter(prefix="/fmu", tags=["fmu"])
 
 
 @router.get("/", response_model=FMUProject)
-async def get_cwd_fmu_directory_session(response: Response) -> FMUProject:
+async def get_cwd_fmu_directory_session(
+    response: Response, user_fmu_dir: UserFMUDirDep
+) -> FMUProject:
     """Returns the paths and configuration for the nearest .fmu directory.
 
     This directory is searched for above the current working directory.
@@ -51,7 +53,7 @@ async def get_cwd_fmu_directory_session(response: Response) -> FMUProject:
 
 @router.post("/", response_model=FMUProject)
 async def get_fmu_directory_session(
-    response: Response, fmu_dir_path: FMUDirPath
+    response: Response, fmu_dir_path: FMUDirPath, user_fmu_dir: UserFMUDirDep
 ) -> FMUProject:
     """Returns the paths and configuration for the .fmu directory at 'path'."""
     path = fmu_dir_path.path
@@ -104,7 +106,9 @@ async def delete_fmu_directory_session(
 
 @router.post("/init", response_model=FMUProject)
 async def init_fmu_directory_session(
-    response: Response, fmu_dir_path: FMUDirPath
+    response: Response,
+    fmu_dir_path: FMUDirPath,
+    user_fmu_dir: UserFMUDirDep,
 ) -> FMUProject:
     """Initializes .fmu at 'path' and returns its paths and configuration."""
     path = fmu_dir_path.path

--- a/tests/test_v1/test_fmu.py
+++ b/tests/test_v1/test_fmu.py
@@ -1,12 +1,15 @@
 """Tests the /api/v1/fmu routes."""
 
+import json
 import stat
 from pathlib import Path
 from unittest.mock import patch
 
 from fastapi import status
 from fastapi.testclient import TestClient
-from fmu.settings._init import init_fmu_directory
+from fmu.settings._fmu_dir import UserFMUDirectory
+from fmu.settings._init import init_fmu_directory, init_user_fmu_directory
+from fmu.settings.models.user_config import UserConfig
 from pytest import MonkeyPatch
 
 from fmu_settings_api.__main__ import app
@@ -33,11 +36,73 @@ def test_get_fmu_invalid_token() -> None:
     assert response.json() == {"detail": "Not authorized"}
 
 
+def test_get_fmu_unauthorized_does_not_create_user_fmu(
+    tmp_path_mocked_home: Path,
+) -> None:
+    """Tests unauthenticated requests do not create a user .fmu."""
+    response = client.get(ROUTE, headers={})
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {"detail": "Not authenticated"}
+    assert not (tmp_path_mocked_home / "home/.fmu").exists()
+
+
+# User FMU Directory dependency errors #
+
+
+def test_create_user_fmu_no_permissions(
+    user_fmu_dir_no_permissions: Path, mock_token: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests that user .fmu directory permissions errors return a 403."""
+    monkeypatch.chdir(user_fmu_dir_no_permissions)
+    response = client.get(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {"detail": "Permission denied creating user .fmu"}
+
+
+def test_create_user_fmu_exists_as_a_file(
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests that a user .fmu as a file raises a 409."""
+    (tmp_path_mocked_home / "home/.fmu").touch()
+    monkeypatch.chdir(tmp_path_mocked_home)
+    response = client.get(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert response.json() == {
+        "detail": "User .fmu already exists but is invalid (i.e. is not a directory)"
+    }
+
+
+def test_create_user_unknown_failure(
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests that an unknown exception returns 500."""
+    with patch(
+        "fmu_settings_api.deps.init_user_fmu_directory",
+        side_effect=Exception("foo"),
+    ):
+        user_fmu_path = tmp_path_mocked_home / "home/.fmu"
+        assert not user_fmu_path.exists()
+
+        monkeypatch.chdir(tmp_path_mocked_home)
+        init_fmu_directory(tmp_path_mocked_home)
+        response = client.get(
+            ROUTE,
+            headers={settings.TOKEN_HEADER_NAME: mock_token},
+        )
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
 # GET fmu/ #
 
 
 def test_get_cwd_fmu_directory_no_permissions(
-    mock_token: str, fmu_dir_no_permissions: Path, monkeypatch: MonkeyPatch
+    fmu_dir_no_permissions: Path, mock_token: str, monkeypatch: MonkeyPatch
 ) -> None:
     """Test 403 returns when lacking permissions somewhere in the path tree."""
     ert_model_path = fmu_dir_no_permissions / "project/24.0.3/ert/model"
@@ -51,11 +116,31 @@ def test_get_cwd_fmu_directory_no_permissions(
     assert response.json() == {"detail": "Permission denied locating .fmu"}
 
 
+def test_get_cwd_fmu_directory_no_permissions_creates_user_fmu(
+    fmu_dir_no_permissions: Path, mock_token: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests an authenticated but erroroneous requests still creates a user .fmu."""
+    ert_model_path = fmu_dir_no_permissions / "project/24.0.3/ert/model"
+    ert_model_path.mkdir(parents=True)
+    monkeypatch.chdir(ert_model_path)
+    response = client.get(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {"detail": "Permission denied locating .fmu"}
+
+    user_fmu_path = fmu_dir_no_permissions / "home/.fmu"
+    assert user_fmu_path.exists()
+    assert user_fmu_path.is_dir()
+    assert user_fmu_path == UserFMUDirectory().path
+
+
 def test_get_cwd_fmu_directory_does_not_exist(
-    mock_token: str, tmp_path: Path, monkeypatch: MonkeyPatch
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
 ) -> None:
     """Test 404 returns when .fmu or directory does not exist from the cwd."""
-    ert_model_path = tmp_path / "project/24.0.3/ert/model"
+    ert_model_path = tmp_path_mocked_home / "project/24.0.3/ert/model"
     ert_model_path.mkdir(parents=True)
     monkeypatch.chdir(ert_model_path)
     response = client.get(
@@ -69,16 +154,16 @@ def test_get_cwd_fmu_directory_does_not_exist(
 
 
 def test_get_cwd_fmu_directory_is_not_directory(
-    mock_token: str, tmp_path: Path, monkeypatch: MonkeyPatch
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
 ) -> None:
     """Test 404 returns when .fmu exists but is not a directory.
 
     Although a .fmu file exists, because a .fmu _directory_ is not, it is
     treated as a 404.
     """
-    path = tmp_path / ".fmu"
+    path = tmp_path_mocked_home / ".fmu"
     path.touch()
-    ert_model_path = tmp_path / "project/24.0.3/ert/model"
+    ert_model_path = tmp_path_mocked_home / "project/24.0.3/ert/model"
     ert_model_path.mkdir(parents=True)
     monkeypatch.chdir(ert_model_path)
 
@@ -92,7 +177,9 @@ def test_get_cwd_fmu_directory_is_not_directory(
     }
 
 
-def test_get_cwd_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
+def test_get_cwd_fmu_directory_raises_other_exceptions(
+    tmp_path_mocked_home: Path, mock_token: str
+) -> None:
     """Test 500 returns if other exceptions are raised."""
     with patch(
         "fmu_settings_api.v1.routes.fmu.find_nearest_fmu_directory",
@@ -107,11 +194,11 @@ def test_get_cwd_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
 
 
 def test_get_cwd_fmu_directory_exists(
-    mock_token: str, tmp_path: Path, monkeypatch: MonkeyPatch
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
 ) -> None:
     """Test 200 and config returns when .fmu exists."""
-    fmu_dir = init_fmu_directory(tmp_path)
-    ert_model_path = tmp_path / "project/24.0.3/ert/model"
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
+    ert_model_path = tmp_path_mocked_home / "project/24.0.3/ert/model"
     ert_model_path.mkdir(parents=True)
     monkeypatch.chdir(ert_model_path)
 
@@ -121,17 +208,67 @@ def test_get_cwd_fmu_directory_exists(
     )
     assert response.status_code == status.HTTP_200_OK
     fmu_project = FMUProject.model_validate(response.json())
-    assert fmu_project.path == tmp_path
-    assert fmu_project.project_dir_name == tmp_path.name
+    assert fmu_project.path == tmp_path_mocked_home
+    assert fmu_project.project_dir_name == tmp_path_mocked_home.name
     assert fmu_dir.config.load() == fmu_project.config
 
 
+def test_get_cwd_fmu_directory_creates_user_fmu_if_not_there(
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests that a user .fmu directory is created as a side effect."""
+    user_fmu_path = tmp_path_mocked_home / "home/.fmu"
+    assert not user_fmu_path.exists()
+
+    monkeypatch.chdir(tmp_path_mocked_home)
+    init_fmu_directory(tmp_path_mocked_home)
+    response = client.get(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    assert user_fmu_path.exists()
+    assert user_fmu_path.is_dir()
+    assert (user_fmu_path / "config.json").exists()
+
+    user_fmu_dir = UserFMUDirectory()
+    assert user_fmu_dir.path == user_fmu_path
+    # Ensure pass isn't a false positive against a non-mocked .fmu dir by validating
+    # timestamps
+    with open(user_fmu_path / "config.json", encoding="utf-8") as f:
+        user_fmu_config = json.loads(f.read())
+    assert user_fmu_dir.config.load() == UserConfig.model_validate(user_fmu_config)
+
+
+def test_get_cwd_fmu_directory_does_not_error_if_user_fmu_exists(
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests that a user .fmu directory already exists causes no issues."""
+    user_fmu_path = tmp_path_mocked_home / "home/.fmu"
+    assert not user_fmu_path.exists()
+    user_fmu_dir = init_user_fmu_directory()
+    assert user_fmu_path.exists()
+    assert user_fmu_path.is_dir()
+    assert user_fmu_path == user_fmu_dir.path
+
+    monkeypatch.chdir(tmp_path_mocked_home)
+    init_fmu_directory(tmp_path_mocked_home)
+    response = client.get(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    assert user_fmu_dir.config.load() == UserFMUDirectory().config.load()
+
+
 async def test_get_fmu_directory_sets_session_cookie(
-    mock_token: str, tmp_path: Path, monkeypatch: MonkeyPatch
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
 ) -> None:
     """Tests that getting an FMU Directory sets a correct session cookie."""
-    fmu_dir = init_fmu_directory(tmp_path)
-    ert_model_path = tmp_path / "project/24.0.3/ert/model"
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
+    ert_model_path = tmp_path_mocked_home / "project/24.0.3/ert/model"
     ert_model_path.mkdir(parents=True)
     monkeypatch.chdir(ert_model_path)
 
@@ -154,7 +291,7 @@ async def test_get_fmu_directory_sets_session_cookie(
 
 
 def test_post_fmu_directory_no_permissions(
-    mock_token: str, fmu_dir_no_permissions: Path
+    fmu_dir_no_permissions: Path, mock_token: str
 ) -> None:
     """Test 403 returns when lacking permissions to path."""
     response = client.post(
@@ -169,7 +306,9 @@ def test_post_fmu_directory_no_permissions(
     assert settings.SESSION_COOKIE_KEY not in response.cookies
 
 
-def test_post_fmu_directory_does_not_exist(mock_token: str) -> None:
+def test_post_fmu_directory_does_not_exist(
+    tmp_path_mocked_home: Path, mock_token: str
+) -> None:
     """Test 404 returns when .fmu or directory does not exist."""
     path = "/dev/null"
     response = client.post(
@@ -182,24 +321,28 @@ def test_post_fmu_directory_does_not_exist(mock_token: str) -> None:
     assert settings.SESSION_COOKIE_KEY not in response.cookies
 
 
-def test_post_fmu_directory_is_not_directory(mock_token: str, tmp_path: Path) -> None:
+def test_post_fmu_directory_is_not_directory(
+    tmp_path_mocked_home: Path, mock_token: str
+) -> None:
     """Test 409 returns when .fmu exists but is not a directory."""
-    path = tmp_path / ".fmu"
+    path = tmp_path_mocked_home / ".fmu"
     path.touch()
 
     response = client.post(
         ROUTE,
         headers={settings.TOKEN_HEADER_NAME: mock_token},
-        json={"path": str(tmp_path)},
+        json={"path": str(tmp_path_mocked_home)},
     )
     assert response.status_code == status.HTTP_409_CONFLICT
     assert response.json() == {
-        "detail": f".fmu exists at {tmp_path} but is not a directory"
+        "detail": f".fmu exists at {tmp_path_mocked_home} but is not a directory"
     }
     assert settings.SESSION_COOKIE_KEY not in response.cookies
 
 
-def test_post_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
+def test_post_fmu_directory_raises_other_exceptions(
+    tmp_path_mocked_home: Path, mock_token: str
+) -> None:
     """Test 500 returns if other exceptions are raised."""
     with patch(
         "fmu_settings_api.v1.routes.fmu.get_fmu_directory", side_effect=Exception("foo")
@@ -215,32 +358,82 @@ def test_post_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
         assert settings.SESSION_COOKIE_KEY not in response.cookies
 
 
-def test_post_fmu_directory_exists(mock_token: str, tmp_path: Path) -> None:
+def test_post_fmu_directory_exists(tmp_path_mocked_home: Path, mock_token: str) -> None:
     """Test 200 and config returns when .fmu exists."""
-    fmu_dir = init_fmu_directory(tmp_path)
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
 
     response = client.post(
         ROUTE,
         headers={settings.TOKEN_HEADER_NAME: mock_token},
-        json={"path": str(tmp_path)},
+        json={"path": str(tmp_path_mocked_home)},
     )
     assert response.status_code == status.HTTP_200_OK
     fmu_project = FMUProject.model_validate(response.json())
-    assert fmu_project.path == tmp_path
-    assert fmu_project.project_dir_name == tmp_path.name
+    assert fmu_project.path == tmp_path_mocked_home
+    assert fmu_project.project_dir_name == tmp_path_mocked_home.name
     assert fmu_dir.config.load() == fmu_project.config
 
 
+def test_post_fmu_directory_creates_user_fmu_if_not_there(
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests that a user .fmu directory is created as a side effect."""
+    user_fmu_path = tmp_path_mocked_home / "home/.fmu"
+    assert not user_fmu_path.exists()
+
+    init_fmu_directory(tmp_path_mocked_home)
+    response = client.post(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path_mocked_home)},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    assert user_fmu_path.exists()
+    assert user_fmu_path.is_dir()
+    assert (user_fmu_path / "config.json").exists()
+
+    user_fmu_dir = UserFMUDirectory()
+    assert user_fmu_dir.path == user_fmu_path
+    # Ensure pass isn't a false positive against a non-mocked .fmu dir by validating
+    # timestamps
+    with open(user_fmu_path / "config.json", encoding="utf-8") as f:
+        user_fmu_config = json.loads(f.read())
+    assert user_fmu_dir.config.load() == UserConfig.model_validate(user_fmu_config)
+
+
+def test_post_fmu_directory_does_not_error_if_user_fmu_exists(
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests that a user .fmu directory already exists causes no issues."""
+    user_fmu_path = tmp_path_mocked_home / "home/.fmu"
+    assert not user_fmu_path.exists()
+    user_fmu_dir = init_user_fmu_directory()
+    assert user_fmu_path.exists()
+    assert user_fmu_path.is_dir()
+    assert user_fmu_path == user_fmu_dir.path
+
+    init_fmu_directory(tmp_path_mocked_home)
+    response = client.post(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path_mocked_home)},
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    assert user_fmu_dir.config.load() == UserFMUDirectory().config.load()
+
+
 async def test_post_fmu_directory_sets_session_cookie(
-    mock_token: str, tmp_path: Path
+    tmp_path_mocked_home: Path, mock_token: str
 ) -> None:
     """Tests that getting an FMU Directory sets a correct session cookie."""
-    fmu_dir = init_fmu_directory(tmp_path)
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
 
     response = client.post(
         ROUTE,
         headers={settings.TOKEN_HEADER_NAME: mock_token},
-        json={"path": str(tmp_path)},
+        json={"path": str(tmp_path_mocked_home)},
     )
     assert response.status_code == status.HTTP_200_OK
     session_id = response.cookies.get(settings.SESSION_COOKIE_KEY, None)
@@ -257,17 +450,17 @@ async def test_post_fmu_directory_sets_session_cookie(
 
 
 async def test_delete_fmu_directory_deletes_session_cookie(
-    mock_token: str, tmp_path: Path
+    tmp_path_mocked_home: Path, mock_token: str
 ) -> None:
     """Tests that deleting a session deletes the session cookie and session."""
     from fmu_settings_api.session import session_manager
 
-    fmu_dir = init_fmu_directory(tmp_path)
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
 
     setup_response = client.post(
         ROUTE,
         headers={settings.TOKEN_HEADER_NAME: mock_token},
-        json={"path": str(tmp_path)},
+        json={"path": str(tmp_path_mocked_home)},
     )
     assert setup_response.status_code == status.HTTP_200_OK
     session_id = setup_response.cookies.get(settings.SESSION_COOKIE_KEY, None)
@@ -282,6 +475,7 @@ async def test_delete_fmu_directory_deletes_session_cookie(
         ROUTE,
         headers={settings.TOKEN_HEADER_NAME: mock_token},
     )
+    assert response.status_code == status.HTTP_200_OK
     assert (
         response.json()["message"]
         == f"FMU directory {fmu_dir.path} closed successfully"
@@ -293,14 +487,30 @@ async def test_delete_fmu_directory_deletes_session_cookie(
     assert session is None
 
 
+def test_delete_fmu_directory_does_not_create_user_fmu(
+    tmp_path_mocked_home: Path, mock_token: str, client_with_session: TestClient
+) -> None:
+    """Tests deleting a .fmu session does not create a user .fmu directory.
+
+    It does not really matter if it does, but it is unexpected behavior if it does.
+    """
+    assert not (tmp_path_mocked_home / "home/.fmu").exists()
+    response = client_with_session.delete(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert not (tmp_path_mocked_home / "home/.fmu").exists()
+
+
 # POST fmu/init #
 
 
 def test_post_init_fmu_directory_no_permissions(
-    mock_token: str, tmp_path: Path
+    tmp_path_mocked_home: Path, mock_token: str
 ) -> None:
     """Test 403 returns when lacking permissions to path."""
-    path = tmp_path / "foo"
+    path = tmp_path_mocked_home / "foo"
     path.mkdir()
     path.chmod(stat.S_IRUSR)
 
@@ -313,7 +523,9 @@ def test_post_init_fmu_directory_no_permissions(
     assert response.json() == {"detail": f"Permission denied creating .fmu at {path}"}
 
 
-def test_post_init_fmu_directory_does_not_exist(mock_token: str) -> None:
+def test_post_init_fmu_directory_does_not_exist(
+    tmp_path_mocked_home: Path, mock_token: str
+) -> None:
     """Test 404 returns when directory to initialize .fmu does not exist."""
     path = "/dev/null/foo"
     response = client.post(
@@ -326,38 +538,44 @@ def test_post_init_fmu_directory_does_not_exist(mock_token: str) -> None:
 
 
 def test_post_init_fmu_directory_is_not_a_directory(
-    mock_token: str, tmp_path: Path
+    tmp_path_mocked_home: Path, mock_token: str
 ) -> None:
     """Test 409 returns when .fmu exists as a file at a path."""
-    path = tmp_path / ".fmu"
+    path = tmp_path_mocked_home / ".fmu"
     path.touch()
 
     response = client.post(
         f"{ROUTE}/init",
         headers={settings.TOKEN_HEADER_NAME: mock_token},
-        json={"path": str(tmp_path)},
+        json={"path": str(tmp_path_mocked_home)},
     )
     assert response.status_code == status.HTTP_409_CONFLICT
-    assert response.json() == {"detail": f".fmu already exists at {tmp_path}"}
+    assert response.json() == {
+        "detail": f".fmu already exists at {tmp_path_mocked_home}"
+    }
 
 
 def test_post_init_fmu_directory_already_exists(
-    mock_token: str, tmp_path: Path
+    tmp_path_mocked_home: Path, mock_token: str
 ) -> None:
     """Test 409 returns when .fmu exists already at a path."""
-    path = tmp_path / ".fmu"
+    path = tmp_path_mocked_home / ".fmu"
     path.mkdir()
 
     response = client.post(
         f"{ROUTE}/init",
         headers={settings.TOKEN_HEADER_NAME: mock_token},
-        json={"path": str(tmp_path)},
+        json={"path": str(tmp_path_mocked_home)},
     )
     assert response.status_code == status.HTTP_409_CONFLICT
-    assert response.json() == {"detail": f".fmu already exists at {tmp_path}"}
+    assert response.json() == {
+        "detail": f".fmu already exists at {tmp_path_mocked_home}"
+    }
 
 
-def test_post_init_fmu_directory_raises_other_exceptions(mock_token: str) -> None:
+def test_post_init_fmu_directory_raises_other_exceptions(
+    tmp_path_mocked_home: Path, mock_token: str
+) -> None:
     """Test 500 returns if other exceptions are raised."""
     with patch(
         "fmu_settings_api.v1.routes.fmu.init_fmu_directory",
@@ -374,9 +592,10 @@ def test_post_init_fmu_directory_raises_other_exceptions(mock_token: str) -> Non
 
 
 def test_post_init_and_get_fmu_directory_succeeds(
-    mock_token: str, tmp_path: Path
+    tmp_path_mocked_home: Path, mock_token: str
 ) -> None:
     """Test 200 and config returns when .fmu exists."""
+    tmp_path = tmp_path_mocked_home
     init_response = client.post(
         f"{ROUTE}/init",
         headers={settings.TOKEN_HEADER_NAME: mock_token},
@@ -386,6 +605,7 @@ def test_post_init_and_get_fmu_directory_succeeds(
     init_fmu_project = FMUProject.model_validate(init_response.json())
     assert init_fmu_project.path == tmp_path
     assert init_fmu_project.project_dir_name == tmp_path.name
+
     assert (tmp_path / ".fmu").exists()
     assert (tmp_path / ".fmu").is_dir()
     assert (tmp_path / ".fmu/config.json").exists()
@@ -400,14 +620,82 @@ def test_post_init_and_get_fmu_directory_succeeds(
     assert init_fmu_project == get_fmu_project
 
 
+def test_post_init_and_get_fmu_directory_creates_user_fmu_if_not_there(
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests that a user .fmu directory is created as a side effect."""
+    user_fmu_path = tmp_path_mocked_home / "home/.fmu"
+    assert not user_fmu_path.exists()
+
+    tmp_path = tmp_path_mocked_home
+    init_response = client.post(
+        f"{ROUTE}/init",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert init_response.status_code == status.HTTP_200_OK
+
+    user_fmu_dir = UserFMUDirectory()
+    assert user_fmu_dir.path == user_fmu_path
+    # Ensure pass isn't a false positive against a non-mocked .fmu dir by validating
+    # timestamps
+    with open(user_fmu_path / "config.json", encoding="utf-8") as f:
+        user_fmu_config = json.loads(f.read())
+    assert user_fmu_dir.config.load() == UserConfig.model_validate(user_fmu_config)
+
+    get_response = client.post(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert get_response.status_code == status.HTTP_200_OK
+
+    user_fmu_dir = UserFMUDirectory()
+    assert user_fmu_dir.path == user_fmu_path
+    assert user_fmu_dir.config.load() == UserConfig.model_validate(user_fmu_config)
+
+
+def test_post_init_and_get_fmu_directory_does_not_error_if_user_fmu_exists(
+    tmp_path_mocked_home: Path, mock_token: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Tests that a user .fmu directory already exists causes no issues."""
+    user_fmu_path = tmp_path_mocked_home / "home/.fmu"
+    assert not user_fmu_path.exists()
+    user_fmu_dir = init_user_fmu_directory()
+    assert user_fmu_path.exists()
+    assert user_fmu_path.is_dir()
+    assert user_fmu_path == user_fmu_dir.path
+
+    tmp_path = tmp_path_mocked_home
+    init_response = client.post(
+        f"{ROUTE}/init",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert init_response.status_code == status.HTTP_200_OK
+
+    assert user_fmu_dir.config.load() == UserFMUDirectory().config.load()
+
+    get_response = client.post(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={"path": str(tmp_path)},
+    )
+    assert get_response.status_code == status.HTTP_200_OK
+
+    user_fmu_dir = UserFMUDirectory()
+    assert user_fmu_dir.path == user_fmu_path
+    assert user_fmu_dir.config.load() == UserFMUDirectory().config.load()
+
+
 async def test_post_init_succeeds_and_sets_session_cookie(
-    mock_token: str, tmp_path: Path
+    tmp_path_mocked_home: Path, mock_token: str
 ) -> None:
     """Test thats a POST fmu/init succeeds and sets a session cookie."""
     init_response = client.post(
         f"{ROUTE}/init",
         headers={settings.TOKEN_HEADER_NAME: mock_token},
-        json={"path": str(tmp_path)},
+        json={"path": str(tmp_path_mocked_home)},
     )
     assert init_response.status_code == status.HTTP_200_OK
     session_id = init_response.cookies.get(settings.SESSION_COOKIE_KEY, None)
@@ -417,4 +705,4 @@ async def test_post_init_succeeds_and_sets_session_cookie(
 
     session = await session_manager.get_session(session_id)
     assert session is not None
-    assert session.fmu_directory.path == tmp_path / ".fmu"
+    assert session.fmu_directory.path == tmp_path_mocked_home / ".fmu"


### PR DESCRIPTION
Resolves #27

Ensures a user's `$HOME/.fmu/` directory exists when starting an FMU session.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
