### PR TITLE
ENH: Add UserFMUDirectory handle to session instance

### DIFF
--- a/src/fmu_settings_api/session.py
+++ b/src/fmu_settings_api/session.py
@@ -6,6 +6,7 @@ from typing import Self
 from uuid import uuid4
 
 from fmu.settings import ProjectFMUDirectory
+from fmu.settings._fmu_dir import UserFMUDirectory
 
 from fmu_settings_api.config import settings
 
@@ -16,6 +17,7 @@ class Session:
 
     id: str
     fmu_directory: ProjectFMUDirectory
+    user_fmu_directory: UserFMUDirectory
     created_at: datetime
     expires_at: datetime
     last_accessed: datetime
@@ -60,6 +62,7 @@ class SessionManager:
     async def create_session(
         self: Self,
         fmu_directory: ProjectFMUDirectory,
+        user_fmu_directory: UserFMUDirectory,
         expire_seconds: int = settings.SESSION_EXPIRE_SECONDS,
     ) -> str:
         """Creates a new session and stores it to the storage backend."""
@@ -70,6 +73,7 @@ class SessionManager:
         session = Session(
             id=session_id,
             fmu_directory=fmu_directory,
+            user_fmu_directory=user_fmu_directory,
             created_at=now,
             expires_at=now + expiration_duration,
             last_accessed=now,
@@ -99,10 +103,13 @@ session_manager = SessionManager()
 
 async def create_fmu_session(
     fmu_directory: ProjectFMUDirectory,
+    user_fmu_directory: UserFMUDirectory,
     expire_seconds: int = settings.SESSION_EXPIRE_SECONDS,
 ) -> str:
     """Creates a new session and stores it in the session mananger."""
-    return await session_manager.create_session(fmu_directory, expire_seconds)
+    return await session_manager.create_session(
+        fmu_directory, user_fmu_directory, expire_seconds
+    )
 
 
 async def destroy_fmu_session(session_id: str) -> None:

--- a/src/fmu_settings_api/v1/routes/fmu.py
+++ b/src/fmu_settings_api/v1/routes/fmu.py
@@ -25,7 +25,7 @@ async def get_cwd_fmu_directory_session(
     try:
         path = Path.cwd()
         fmu_dir = find_nearest_fmu_directory(path)
-        session_id = await create_fmu_session(fmu_dir)
+        session_id = await create_fmu_session(fmu_dir, user_fmu_dir)
         response.set_cookie(
             key=settings.SESSION_COOKIE_KEY,
             value=session_id,
@@ -59,7 +59,7 @@ async def get_fmu_directory_session(
     path = fmu_dir_path.path
     try:
         fmu_dir = get_fmu_directory(path)
-        session_id = await create_fmu_session(fmu_dir)
+        session_id = await create_fmu_session(fmu_dir, user_fmu_dir)
         response.set_cookie(
             key=settings.SESSION_COOKIE_KEY,
             value=session_id,
@@ -114,7 +114,7 @@ async def init_fmu_directory_session(
     path = fmu_dir_path.path
     try:
         fmu_dir = init_fmu_directory(path)
-        session_id = await create_fmu_session(fmu_dir)
+        session_id = await create_fmu_session(fmu_dir, user_fmu_dir)
         response.set_cookie(
             key=settings.SESSION_COOKIE_KEY,
             value=session_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,10 +86,13 @@ def session_manager() -> Generator[SessionManager]:
 
 
 @pytest.fixture
-async def session_id(tmp_path: Path, session_manager: SessionManager) -> str:
+async def session_id(
+    tmp_path_mocked_home: Path, session_manager: SessionManager
+) -> str:
     """Mocks a valid opened .fmu session."""
-    fmu_dir = init_fmu_directory(tmp_path)
-    return await session_manager.create_session(fmu_dir)
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
+    user_fmu_dir = init_user_fmu_directory()
+    return await session_manager.create_session(fmu_dir, user_fmu_dir)
 
 
 @pytest.fixture

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,9 +2,10 @@
 
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest.mock import patch
 
-from fmu.settings import ProjectFMUDirectory
+from fmu.settings._init import init_fmu_directory, init_user_fmu_directory
 
 from fmu_settings_api.config import settings
 from fmu_settings_api.session import (
@@ -21,50 +22,60 @@ def test_session_manager_init() -> None:
 
 
 async def test_create_session(
-    session_manager: SessionManager, fmu_dir: ProjectFMUDirectory
+    session_manager: SessionManager, tmp_path_mocked_home: Path
 ) -> None:
     """Tests creating a new session."""
-    session_id = await session_manager.create_session(fmu_dir)
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
+    user_fmu_dir = init_user_fmu_directory()
+    session_id = await session_manager.create_session(fmu_dir, user_fmu_dir)
     assert session_id in session_manager.storage
     assert session_manager.storage[session_id].fmu_directory == fmu_dir
     assert len(session_manager.storage) == 1
 
 
 async def test_create_session_wrapper(
-    session_manager: SessionManager, fmu_dir: ProjectFMUDirectory
+    session_manager: SessionManager, tmp_path_mocked_home: Path
 ) -> None:
     """Tests creating a new session with the wrapper."""
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
+    user_fmu_dir = init_user_fmu_directory()
     with patch("fmu_settings_api.session.session_manager", session_manager):
-        session_id = await create_fmu_session(fmu_dir)
+        session_id = await create_fmu_session(fmu_dir, user_fmu_dir)
     assert session_id in session_manager.storage
     assert session_manager.storage[session_id].fmu_directory == fmu_dir
     assert len(session_manager.storage) == 1
 
 
 async def test_get_non_existing_session(
-    session_manager: SessionManager, fmu_dir: ProjectFMUDirectory
+    session_manager: SessionManager, tmp_path_mocked_home: Path
 ) -> None:
     """Tests getting an existing session."""
-    await session_manager.create_session(fmu_dir)
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
+    user_fmu_dir = init_user_fmu_directory()
+    await session_manager.create_session(fmu_dir, user_fmu_dir)
     assert await session_manager.get_session("no") is None
     assert len(session_manager.storage) == 1
 
 
 async def test_get_existing_session(
-    session_manager: SessionManager, fmu_dir: ProjectFMUDirectory
+    session_manager: SessionManager, tmp_path_mocked_home: Path
 ) -> None:
     """Tests getting an existing session."""
-    session_id = await session_manager.create_session(fmu_dir)
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
+    user_fmu_dir = init_user_fmu_directory()
+    session_id = await session_manager.create_session(fmu_dir, user_fmu_dir)
     session = await session_manager.get_session(session_id)
     assert session == session_manager.storage[session_id]
     assert len(session_manager.storage) == 1
 
 
 async def test_get_existing_session_expiration(
-    session_manager: SessionManager, fmu_dir: ProjectFMUDirectory
+    session_manager: SessionManager, tmp_path_mocked_home: Path
 ) -> None:
     """Tests getting an existing session expires."""
-    session_id = await session_manager.create_session(fmu_dir)
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
+    user_fmu_dir = init_user_fmu_directory()
+    session_id = await session_manager.create_session(fmu_dir, user_fmu_dir)
     orig_session = session_manager.storage[session_id]
     expiration_duration = timedelta(seconds=settings.SESSION_EXPIRE_SECONDS)
     assert orig_session.created_at + expiration_duration == orig_session.expires_at
@@ -78,10 +89,12 @@ async def test_get_existing_session_expiration(
 
 
 async def test_get_existing_session_updates_last_accessed(
-    session_manager: SessionManager, fmu_dir: ProjectFMUDirectory
+    session_manager: SessionManager, tmp_path_mocked_home: Path
 ) -> None:
     """Tests getting an existing session updates its last accessed."""
-    session_id = await session_manager.create_session(fmu_dir)
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
+    user_fmu_dir = init_user_fmu_directory()
+    session_id = await session_manager.create_session(fmu_dir, user_fmu_dir)
     orig_session = deepcopy(session_manager.storage[session_id])
     session = await session_manager.get_session(session_id)
     assert session is not None
@@ -89,10 +102,12 @@ async def test_get_existing_session_updates_last_accessed(
 
 
 async def test_destroy_fmu_session(
-    session_manager: SessionManager, fmu_dir: ProjectFMUDirectory
+    session_manager: SessionManager, tmp_path_mocked_home: Path
 ) -> None:
     """Tests destroying a session."""
-    session_id = await session_manager.create_session(fmu_dir)
+    fmu_dir = init_fmu_directory(tmp_path_mocked_home)
+    user_fmu_dir = init_user_fmu_directory()
+    session_id = await session_manager.create_session(fmu_dir, user_fmu_dir)
     with patch("fmu_settings_api.session.session_manager", session_manager):
         await destroy_fmu_session(session_id)
     assert session_id not in session_manager.storage

--- a/tests/test_v1/test_fmu.py
+++ b/tests/test_v1/test_fmu.py
@@ -444,6 +444,7 @@ async def test_post_fmu_directory_sets_session_cookie(
     session = await session_manager.get_session(session_id)
     assert session is not None
     assert session.fmu_directory.path == fmu_dir.path
+    assert session.user_fmu_directory.path == UserFMUDirectory().path
 
 
 # DELETE fmu/ #
@@ -468,6 +469,7 @@ async def test_delete_fmu_directory_deletes_session_cookie(
     session = await session_manager.get_session(session_id)
     assert session is not None
     assert session.fmu_directory.path == fmu_dir.path
+    assert session.user_fmu_directory.path == UserFMUDirectory().path
 
     # Actual test below
 
@@ -485,22 +487,6 @@ async def test_delete_fmu_directory_deletes_session_cookie(
 
     session = await session_manager.get_session(session_id)
     assert session is None
-
-
-def test_delete_fmu_directory_does_not_create_user_fmu(
-    tmp_path_mocked_home: Path, mock_token: str, client_with_session: TestClient
-) -> None:
-    """Tests deleting a .fmu session does not create a user .fmu directory.
-
-    It does not really matter if it does, but it is unexpected behavior if it does.
-    """
-    assert not (tmp_path_mocked_home / "home/.fmu").exists()
-    response = client_with_session.delete(
-        ROUTE,
-        headers={settings.TOKEN_HEADER_NAME: mock_token},
-    )
-    assert response.status_code == status.HTTP_200_OK
-    assert not (tmp_path_mocked_home / "home/.fmu").exists()
 
 
 # POST fmu/init #
@@ -706,3 +692,4 @@ async def test_post_init_succeeds_and_sets_session_cookie(
     session = await session_manager.get_session(session_id)
     assert session is not None
     assert session.fmu_directory.path == tmp_path_mocked_home / ".fmu"
+    assert session.user_fmu_directory.path == UserFMUDirectory().path


### PR DESCRIPTION
Resolves #29

A session should keep the UserFMUDirectory instance for quick access.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
