### PR TITLE
ENH: Accept and store API keys to user config

### DIFF
--- a/src/fmu_settings_api/models/common.py
+++ b/src/fmu_settings_api/models/common.py
@@ -1,9 +1,16 @@
 """Common response models from the API."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 
 class Message(BaseModel):
     """A generic message to return to the GUI."""
 
     message: str
+
+
+class APIKey(BaseModel):
+    """A key-value pair for a known and supported API."""
+
+    id: str
+    key: SecretStr

--- a/src/fmu_settings_api/v1/main.py
+++ b/src/fmu_settings_api/v1/main.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends
 from fmu_settings_api.config import settings
 from fmu_settings_api.deps import verify_auth_token
 
-from .routes import config, fmu
+from .routes import config, fmu, user
 
 api_v1_router = APIRouter(
     prefix=settings.API_V1_PREFIX,
@@ -14,6 +14,7 @@ api_v1_router = APIRouter(
 )
 api_v1_router.include_router(fmu.router)
 api_v1_router.include_router(config.router)
+api_v1_router.include_router(user.router)
 
 
 @api_v1_router.get("/health")

--- a/src/fmu_settings_api/v1/routes/user.py
+++ b/src/fmu_settings_api/v1/routes/user.py
@@ -1,0 +1,64 @@
+"""Routes to operate on the .fmu config file."""
+
+from fastapi import APIRouter, HTTPException
+from fmu.settings.models.user_config import UserAPIKeys, UserConfig
+
+from fmu_settings_api.deps import SessionDep
+from fmu_settings_api.models.common import APIKey, Message
+
+router = APIRouter(prefix="/user", tags=["user"])
+
+
+@router.get("/", response_model=UserConfig)
+async def get_fmu_directory_config(session: SessionDep) -> UserConfig:
+    """Returns the user configuration of the current session."""
+    try:
+        config = session.user_fmu_directory.config
+        config_dict = config.load().model_dump()
+
+        # Overwrite secret keys with obfuscated keys
+        for k, v in config_dict["user_api_keys"].items():
+            if v is not None:
+                # Convert SecretStr("*********") to "*********"
+                config_dict["user_api_keys"][k] = str(v)
+
+        return UserConfig.model_validate(config_dict)
+    except PermissionError as e:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Permission denied loading user .fmu config at {config.path}",
+        ) from e
+    except FileNotFoundError as e:
+        raise HTTPException(
+            status_code=404, detail=f"User .fmu config at {config.path} does not exist"
+        ) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.patch("/api_key")
+async def patch_api_token_key(
+    session: SessionDep,
+    api_key: APIKey,
+) -> Message:
+    """Patches the API key for a known and supported API."""
+    if api_key.id not in UserAPIKeys.model_fields:
+        raise HTTPException(
+            status_code=422, detail=f"API id {api_key.id} is not known or supported"
+        )
+
+    try:
+        session.user_fmu_directory.set_config_value(
+            f"user_api_keys.{api_key.id}", api_key.key
+        )
+        return Message(message=f"Saved API key for {api_key.id}")
+    except FileNotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"User .fmu config at {session.user_fmu_directory.config.path} does "
+                "not exist"
+            ),
+        ) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/tests/test_v1/test_user.py
+++ b/tests/test_v1/test_user.py
@@ -1,0 +1,106 @@
+"""Tests the /api/v1/user routes."""
+
+from fastapi import status
+from fastapi.testclient import TestClient
+from fmu.settings._fmu_dir import UserFMUDirectory
+from fmu.settings.models.user_config import UserConfig
+
+from fmu_settings_api.__main__ import app
+from fmu_settings_api.config import settings
+
+client = TestClient(app)
+
+ROUTE = "/api/v1/user"
+
+
+def test_get_user_fmu_unauthenticated() -> None:
+    """Tests that user routes required a token."""
+    response = client.get(ROUTE, headers={})
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {"detail": "Not authenticated"}
+
+
+def test_get_user_fmu_no_session(mock_token: str) -> None:
+    """Tests that user routes required a session."""
+    response = client.get(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "No active session found"}
+
+
+def test_get_user_fmu_config(client_with_session: TestClient, mock_token: str) -> None:
+    """Tests that getting a user config functions correctly."""
+    response = client_with_session.get(
+        ROUTE,
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    user_fmu_dir = UserFMUDirectory()
+    assert user_fmu_dir.config.load() == UserConfig.model_validate(response.json())
+
+
+def test_patch_invalid_api_token_key_to_user_fmu_config(
+    client_with_session: TestClient, mock_token: str
+) -> None:
+    """Tests that submitting an unsupported API does return 422."""
+    response = client_with_session.patch(
+        f"{ROUTE}/api_key",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={
+            "id": "foo",
+            "key": "secret",
+        },
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert response.json()["detail"] == "API id foo is not known or supported"
+
+
+def test_patch_api_token_to_user_fmu_config(
+    client_with_session: TestClient, mock_token: str
+) -> None:
+    """Tests that submitting a valid API key pair saved to the user configuration."""
+    user_fmu_dir = UserFMUDirectory()
+    assert user_fmu_dir.get_config_value("user_api_keys.smda_subscription") is None
+
+    response = client_with_session.patch(
+        f"{ROUTE}/api_key",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={
+            "id": "smda_subscription",
+            "key": "secret",
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["message"] == "Saved API key for smda_subscription"
+
+    user_fmu_dir = UserFMUDirectory()
+    assert (
+        user_fmu_dir.get_config_value(
+            "user_api_keys.smda_subscription"
+        ).get_secret_value()
+        == "secret"
+    )
+
+
+def test_api_token_is_not_leaked_with_user_fmu_config(
+    client_with_session: TestClient, mock_token: str
+) -> None:
+    """Tests that retrieving the user configuration does not leak API tokens."""
+    response = client_with_session.patch(
+        f"{ROUTE}/api_key",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+        json={
+            "id": "smda_subscription",
+            "key": "secret",
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    response = client_with_session.get(
+        f"{ROUTE}",
+        headers={settings.TOKEN_HEADER_NAME: mock_token},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["user_api_keys"]["smda_subscription"] == "**********"


### PR DESCRIPTION
Resolves #22

Currently all `/user` routes require an FMU session. This shouldn't necessarily be a requirement and will be relaxed in a follow-up PR.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
