### PR TITLE
ENH: Switch requests for httpx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,14 @@ dynamic = ["version"]
 dependencies = [
     "fastapi",
     "fmu-settings @ git+https://github.com/equinor/fmu-settings",
+    "httpx",
     "pydantic",
-    "requests",
     "uvicorn",
 ]
 
 [project.optional-dependencies]
 dev = [
     "python-dotenv",
-    "httpx",
     "mypy",
     "pytest",
     "pytest-asyncio",

--- a/src/fmu_settings_api/interfaces/smda_api.py
+++ b/src/fmu_settings_api/interfaces/smda_api.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Final
 
-import requests
+import httpx
 
 
 class SmdaRoutes:
@@ -26,42 +26,44 @@ class SmdaAPI:
             "Ocp-Apim-Subscription-Key": self._subscription_key,
         }
 
-    async def get(self, route: str) -> requests.Response:
+    async def get(self, route: str) -> httpx.Response:
         """Makes a GET request to SMDA.
 
         Returns:
-            The requests response on success
+            The httpx response on success
 
         Raises:
-            requests.exceptions.HTTPError if not 200
+            httpx.HTTPError if not 200
         """
         url = f"{SmdaRoutes.BASE_URL}/{route}"
-        res = requests.get(url, headers=self._headers)
+        async with httpx.AsyncClient() as client:
+            res = await client.get(url, headers=self._headers)
         res.raise_for_status()
         return res
 
     async def post(
         self, route: str, json: dict[str, Any] | None = None
-    ) -> requests.Response:
+    ) -> httpx.Response:
         """Makes a POST request to SMDA.
 
         Returns:
-            The requests response on success
+            The httpx response on success
 
         Raises:
-            requests.exceptions.HTTPError if not 200
+            httpx.HTTPError if not 200
         """
         url = f"{SmdaRoutes.BASE_URL}/{route}"
-        res = requests.post(url, headers=self._headers, json=json)
+        async with httpx.AsyncClient() as client:
+            res = await client.post(url, headers=self._headers, json=json)
         res.raise_for_status()
         return res
 
     async def health(self) -> bool:
         """Checks if the access token and subscription key are valid."""
         res = await self.get(SmdaRoutes.HEALTH)
-        return res.status_code == requests.codes.ok
+        return res.status_code == httpx.codes.OK
 
-    async def field(self, field_identifier: str) -> requests.Response:
+    async def field(self, field_identifier: str) -> httpx.Response:
         """Searches for a field identifier in SMDA."""
         return await self.post(
             SmdaRoutes.FIELD_SEARCH,

--- a/tests/test_interfaces/test_smda_api.py
+++ b/tests/test_interfaces/test_smda_api.py
@@ -9,33 +9,35 @@ from fmu_settings_api.interfaces.smda_api import SmdaAPI, SmdaRoutes
 
 
 @pytest.fixture
-def mock_requests_get() -> Generator[MagicMock]:
+def mock_httpx_get() -> Generator[MagicMock]:
     """Mocks methods on SmdaAPI."""
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
     with patch(
-        "fmu_settings_api.interfaces.smda_api.requests.get", return_value=mock_response
+        "fmu_settings_api.interfaces.smda_api.httpx.AsyncClient.get",
+        return_value=mock_response,
     ) as get:
         yield get
 
 
 @pytest.fixture
-def mock_requests_post() -> Generator[MagicMock]:
+def mock_httpx_post() -> Generator[MagicMock]:
     """Mocks methods on SmdaAPI."""
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
     with patch(
-        "fmu_settings_api.interfaces.smda_api.requests.post", return_value=mock_response
+        "fmu_settings_api.interfaces.smda_api.httpx.AsyncClient.post",
+        return_value=mock_response,
     ) as post:
         yield post
 
 
-async def test_smda_get(mock_requests_get: MagicMock) -> None:
+async def test_smda_get(mock_httpx_get: MagicMock) -> None:
     """Tests the GET method on the SMDA interface."""
     api = SmdaAPI("token", "key")
     res = await api.get(SmdaRoutes.HEALTH)
 
-    mock_requests_get.assert_called_with(
+    mock_httpx_get.assert_called_with(
         f"{SmdaRoutes.BASE_URL}/{SmdaRoutes.HEALTH}",
         headers={
             "Content-Type": "application/json",
@@ -46,12 +48,12 @@ async def test_smda_get(mock_requests_get: MagicMock) -> None:
     res.raise_for_status.assert_called_once()  # type: ignore
 
 
-async def test_smda_post_with_json(mock_requests_post: MagicMock) -> None:
+async def test_smda_post_with_json(mock_httpx_post: MagicMock) -> None:
     """Tests the POST method on the SMDA interface with json."""
     api = SmdaAPI("token", "key")
     res = await api.post(SmdaRoutes.HEALTH, json={"a": "b"})
 
-    mock_requests_post.assert_called_with(
+    mock_httpx_post.assert_called_with(
         f"{SmdaRoutes.BASE_URL}/{SmdaRoutes.HEALTH}",
         headers={
             "Content-Type": "application/json",
@@ -63,12 +65,12 @@ async def test_smda_post_with_json(mock_requests_post: MagicMock) -> None:
     res.raise_for_status.assert_called_once()  # type: ignore
 
 
-async def test_smda_post_without_json(mock_requests_post: MagicMock) -> None:
+async def test_smda_post_without_json(mock_httpx_post: MagicMock) -> None:
     """Tests the POST method on the SMDA interface without."""
     api = SmdaAPI("token", "key")
     res = await api.post(SmdaRoutes.HEALTH)
 
-    mock_requests_post.assert_called_with(
+    mock_httpx_post.assert_called_with(
         f"{SmdaRoutes.BASE_URL}/{SmdaRoutes.HEALTH}",
         headers={
             "Content-Type": "application/json",

--- a/tests/test_v1/test_smda.py
+++ b/tests/test_v1/test_smda.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import httpx
 import pytest
-import requests
 from fastapi import status
 from fastapi.testclient import TestClient
 
@@ -67,8 +67,8 @@ async def test_get_health_has_user_api_key_and_access_token(
     mock_SmdaAPI_get: AsyncMock,
 ) -> None:
     """Test 401 returns when an API key exists but an SMDA access token is not set."""
-    mock_response = MagicMock(spec=requests.Response)
-    mock_response.status_code = requests.codes.ok
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = httpx.codes.OK
     mock_response.json.return_value = {"status": "ok"}
 
     mock_SmdaAPI_get.return_value = mock_response
@@ -84,9 +84,7 @@ async def test_get_health_request_failure_raises_exception(
     mock_SmdaAPI_get: AsyncMock,
 ) -> None:
     """Tests the request to SMDA failing as a 500 error."""
-    mock_SmdaAPI_get.side_effect = requests.exceptions.HTTPError(
-        "401 Client Error: Access Denied"
-    )
+    mock_SmdaAPI_get.side_effect = httpx.HTTPError("401 Client Error: Access Denied")
 
     response = client_with_smda_session.get(f"{ROUTE}/health")
 
@@ -103,7 +101,7 @@ async def test_post_field_succeeds_with_one(
 ) -> None:
     """Tests that posting a valid search returns a valid result."""
     uuid = uuid4()
-    mock_response = MagicMock(spec=requests.Response)
+    mock_response = MagicMock(spec=httpx.Response)
     mock_response.status_code = 200
     mock_response.json.return_value = {
         "data": {
@@ -141,7 +139,7 @@ async def test_post_field_succeeds_with_none(
     mock_SmdaAPI_post: AsyncMock,
 ) -> None:
     """Tests that posting a valid but non-existent search returns an empty result."""
-    mock_response = MagicMock(spec=requests.Response)
+    mock_response = MagicMock(spec=httpx.Response)
     mock_response.status_code = 200
     mock_response.json.return_value = {
         "data": {
@@ -173,7 +171,7 @@ async def test_post_field_with_no_identifier_raises(
     mock_SmdaAPI_post: AsyncMock,
 ) -> None:
     """Tests that posting an empty field identifier is valid but returns no data."""
-    mock_response = MagicMock(spec=requests.Response)
+    mock_response = MagicMock(spec=httpx.Response)
     mock_response.status_code = 200
     mock_response.json.return_value = {
         "data": {
@@ -202,7 +200,7 @@ async def test_post_field_has_bad_response_raises(
     mock_SmdaAPI_post: AsyncMock,
 ) -> None:
     """Tests that posting a valid response with an invalid response from SMDA fails."""
-    mock_response = MagicMock(spec=requests.Response)
+    mock_response = MagicMock(spec=httpx.Response)
     mock_response.status_code = 200
     mock_response.json.return_value = {}
 


### PR DESCRIPTION
Resolves #72 

Requests does not have an async client.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
