### PR TITLE
CONF: Add HttpHeader enum for fixed header values

### DIFF
--- a/src/fmu_settings_api/__main__.py
+++ b/src/fmu_settings_api/__main__.py
@@ -65,7 +65,7 @@ def run_server(  # noqa PLR0913
             allow_credentials=True,
             allow_methods=["*"],
             allow_headers=["*"],
-            expose_headers=["x-upstream-source"],
+            expose_headers=[settings.X_UPSTREAM_SOURCE_HEADER_KEY],
         )
 
     def signal_handler(signum: int, frame: FrameType | None) -> None:

--- a/src/fmu_settings_api/__main__.py
+++ b/src/fmu_settings_api/__main__.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from fastapi.routing import APIRoute
 from starlette.middleware.cors import CORSMiddleware
 
-from .config import settings
+from .config import HttpHeader, settings
 from .models import Ok
 from .v1.main import api_v1_router
 
@@ -65,7 +65,7 @@ def run_server(  # noqa PLR0913
             allow_credentials=True,
             allow_methods=["*"],
             allow_headers=["*"],
-            expose_headers=[settings.X_UPSTREAM_SOURCE_HEADER_KEY],
+            expose_headers=[HttpHeader.UPSTREAM_SOURCE_KEY],
         )
 
     def signal_handler(signum: int, frame: FrameType | None) -> None:

--- a/src/fmu_settings_api/config.py
+++ b/src/fmu_settings_api/config.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import secrets
-from typing import Annotated, Any, Self
+from typing import Annotated, Any, Final, Self
 
 from pydantic import (
     BaseModel,
@@ -39,11 +39,24 @@ def parse_cors(v: Any) -> list[HttpUrl]:
     raise ValueError(f"Invalid list of origins: {v}")
 
 
+class HttpHeader:
+    """Contains Http header keys and values for API requests."""
+
+    API_TOKEN_KEY: Final[str] = "x-fmu-settings-api"
+    UPSTREAM_SOURCE_KEY: Final[str] = "x-upstream-source"
+    UPSTREAM_SOURCE_SMDA: Final[str] = "SMDA"
+    WWW_AUTHENTICATE_KEY: Final[str] = "WWW-Authenticate"
+    WWW_AUTHENTICATE_COOKIE: Final[str] = "Cookie-Auth"
+    CONTENT_TYPE_KEY: Final[str] = "Content-Type"
+    CONTENT_TYPE_JSON: Final[str] = "application/json"
+    AUTHORIZATION_KEY: Final[str] = "authorization"
+    OCP_APIM_SUBSCRIPTION_KEY: Final[str] = "Ocp-Apim-Subscription-Key"
+
+
 class APISettings(BaseModel):
     """Settings used for the API."""
 
     API_V1_PREFIX: str = Field(default="/api/v1", frozen=True)
-    TOKEN_HEADER_NAME: str = Field(default="x-fmu-settings-api", frozen=True)
     TOKEN: str = Field(
         default_factory=generate_auth_token,
         pattern=r"^[a-fA-F0-9]{64}$",
@@ -55,7 +68,6 @@ class APISettings(BaseModel):
 
     FRONTEND_HOST: HttpUrl = Field(default=HttpUrl("http://localhost:8000"))
     BACKEND_CORS_ORIGINS: Annotated[list[HttpUrl], BeforeValidator(parse_cors)] = []
-    X_UPSTREAM_SOURCE_HEADER_KEY: str = Field(default="x-upstream-source", frozen=True)
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/src/fmu_settings_api/config.py
+++ b/src/fmu_settings_api/config.py
@@ -55,6 +55,7 @@ class APISettings(BaseModel):
 
     FRONTEND_HOST: HttpUrl = Field(default=HttpUrl("http://localhost:8000"))
     BACKEND_CORS_ORIGINS: Annotated[list[HttpUrl], BeforeValidator(parse_cors)] = []
+    X_UPSTREAM_SOURCE_HEADER_KEY: str = Field(default="x-upstream-source", frozen=True)
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/src/fmu_settings_api/deps.py
+++ b/src/fmu_settings_api/deps.py
@@ -7,7 +7,7 @@ from fastapi.security import APIKeyHeader
 from fmu.settings._fmu_dir import UserFMUDirectory
 from fmu.settings._init import init_user_fmu_directory
 
-from fmu_settings_api.config import settings
+from fmu_settings_api.config import HttpHeader, settings
 from fmu_settings_api.session import (
     ProjectSession,
     Session,
@@ -15,7 +15,7 @@ from fmu_settings_api.session import (
     session_manager,
 )
 
-api_token_header = APIKeyHeader(name=settings.TOKEN_HEADER_NAME)
+api_token_header = APIKeyHeader(name=HttpHeader.API_TOKEN_KEY)
 
 TokenHeaderDep = Annotated[str, Security(api_token_header)]
 
@@ -80,7 +80,9 @@ async def get_session(
         raise HTTPException(
             status_code=401,
             detail="No active session found",
-            headers={"WWW-Authenticate": "Cookie-Auth"},
+            headers={
+                HttpHeader.WWW_AUTHENTICATE_KEY: HttpHeader.WWW_AUTHENTICATE_COOKIE
+            },
         )
     try:
         return await session_manager.get_session(fmu_settings_session)
@@ -88,7 +90,9 @@ async def get_session(
         raise HTTPException(
             status_code=401,
             detail="Invalid or expired session",
-            headers={"WWW-Authenticate": "Cookie-Auth"},
+            headers={
+                HttpHeader.WWW_AUTHENTICATE_KEY: HttpHeader.WWW_AUTHENTICATE_COOKIE
+            },
         ) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Session error: {e}") from e
@@ -122,13 +126,13 @@ async def ensure_smda_session(session: Session) -> None:
         raise HTTPException(
             status_code=401,
             detail="User SMDA API key is not configured",
-            headers={"x-upstream-source": "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         )
     if session.access_tokens.smda_api is None:
         raise HTTPException(
             status_code=401,
             detail="SMDA access token is not set",
-            headers={"x-upstream-source": "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         )
 
 

--- a/src/fmu_settings_api/interfaces/smda_api.py
+++ b/src/fmu_settings_api/interfaces/smda_api.py
@@ -5,6 +5,8 @@ from typing import Any, Final
 
 import httpx
 
+from fmu_settings_api.config import HttpHeader
+
 
 class SmdaRoutes:
     """Contains routes used by routes in this API."""
@@ -26,9 +28,9 @@ class SmdaAPI:
         self._access_token = access_token
         self._subscription_key = subscription_key
         self._headers = {
-            "Content-Type": "application/json",
-            "authorization": f"Bearer {self._access_token}",
-            "Ocp-Apim-Subscription-Key": self._subscription_key,
+            HttpHeader.CONTENT_TYPE_KEY: HttpHeader.CONTENT_TYPE_JSON,
+            HttpHeader.AUTHORIZATION_KEY: f"Bearer {self._access_token}",
+            HttpHeader.OCP_APIM_SUBSCRIPTION_KEY: self._subscription_key,
         }
 
     async def get(self, route: str) -> httpx.Response:

--- a/src/fmu_settings_api/v1/routes/smda/main.py
+++ b/src/fmu_settings_api/v1/routes/smda/main.py
@@ -11,6 +11,7 @@ from fmu.settings.models.smda import (
     FieldItem,
 )
 
+from fmu_settings_api.config import settings
 from fmu_settings_api.deps import (
     ProjectSmdaSessionDep,
     SessionDep,
@@ -33,7 +34,7 @@ from fmu_settings_api.v1.responses import GetSessionResponses, inline_add_respon
 
 def _add_response_headers(response: Response) -> Generator[None]:
     """Adds headers specific to the /smda route."""
-    response.headers["x-upstream-source"] = "SMDA"
+    response.headers[settings.X_UPSTREAM_SOURCE_HEADER_KEY] = "SMDA"
     yield
 
 
@@ -70,7 +71,7 @@ async def get_health(session: SessionDep) -> Ok:
         raise HTTPException(
             status_code=401,
             detail="SMDA access token is not set",
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         )
 
     try:
@@ -86,13 +87,13 @@ async def get_health(session: SessionDep) -> Ok:
         raise HTTPException(
             status_code=e.response.status_code,
             detail=f"SMDA error requesting {e.request.url}",
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         ) from e
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=str(e),
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         ) from e
 
 
@@ -125,7 +126,7 @@ async def post_field(session: SessionDep, field: SmdaField) -> SmdaFieldSearchRe
         raise HTTPException(
             status_code=401,
             detail="SMDA access token is not set",
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         )
 
     try:
@@ -143,25 +144,25 @@ async def post_field(session: SessionDep, field: SmdaField) -> SmdaFieldSearchRe
         raise HTTPException(
             status_code=e.response.status_code,
             detail=f"SMDA error requesting {e.request.url!r}",
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         ) from e
     except KeyError as e:
         raise HTTPException(
             status_code=500,
             detail="Malformed response from SMDA: no 'data' field present",
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         ) from e
     except TimeoutError as e:
         raise HTTPException(
             status_code=503,
             detail="SMDA API request timed out. Please try again.",
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         ) from e
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=str(e),
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         ) from e
 
 
@@ -215,7 +216,7 @@ async def post_masterdata(
         raise HTTPException(
             status_code=401,
             detail="SMDA access token is not set",
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         )
 
     # Sorted for tests as sets don't guarantee order
@@ -243,7 +244,7 @@ async def post_masterdata(
             raise HTTPException(
                 status_code=404,
                 detail=f"No fields found for identifiers: {unique_field_identifiers}",
-                headers={"x-upstream-source": "SMDA"},
+                headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
             )
 
         field_items = [FieldItem(**field) for field in field_results]
@@ -277,7 +278,7 @@ async def post_masterdata(
             raise HTTPException(
                 status_code=404,
                 detail="Projected field coordinate system not found",
-                headers={"x-upstream-source": "SMDA"},
+                headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
             )
 
         return SmdaMasterdataResult(
@@ -294,23 +295,23 @@ async def post_masterdata(
         raise HTTPException(
             status_code=e.response.status_code,
             detail=f"SMDA error requesting {e.request.url}",
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         ) from e
     except KeyError as e:
         raise HTTPException(
             status_code=500,
             detail="Malformed response from SMDA: {e}",
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         ) from e
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=str(e),
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         ) from e
     except TimeoutError as e:
         raise HTTPException(
             status_code=503,
             detail="SMDA API request timed out. Please try again.",
-            headers={"x-upstream-source": "SMDA"},
+            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
         ) from e

--- a/src/fmu_settings_api/v1/routes/smda/main.py
+++ b/src/fmu_settings_api/v1/routes/smda/main.py
@@ -11,7 +11,7 @@ from fmu.settings.models.smda import (
     FieldItem,
 )
 
-from fmu_settings_api.config import settings
+from fmu_settings_api.config import HttpHeader
 from fmu_settings_api.deps import (
     ProjectSmdaSessionDep,
     SessionDep,
@@ -34,7 +34,7 @@ from fmu_settings_api.v1.responses import GetSessionResponses, inline_add_respon
 
 def _add_response_headers(response: Response) -> Generator[None]:
     """Adds headers specific to the /smda route."""
-    response.headers[settings.X_UPSTREAM_SOURCE_HEADER_KEY] = "SMDA"
+    response.headers[HttpHeader.UPSTREAM_SOURCE_KEY] = HttpHeader.UPSTREAM_SOURCE_SMDA
     yield
 
 
@@ -71,7 +71,7 @@ async def get_health(session: SessionDep) -> Ok:
         raise HTTPException(
             status_code=401,
             detail="SMDA access token is not set",
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         )
 
     try:
@@ -87,13 +87,13 @@ async def get_health(session: SessionDep) -> Ok:
         raise HTTPException(
             status_code=e.response.status_code,
             detail=f"SMDA error requesting {e.request.url}",
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         ) from e
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=str(e),
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         ) from e
 
 
@@ -126,7 +126,7 @@ async def post_field(session: SessionDep, field: SmdaField) -> SmdaFieldSearchRe
         raise HTTPException(
             status_code=401,
             detail="SMDA access token is not set",
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         )
 
     try:
@@ -144,25 +144,25 @@ async def post_field(session: SessionDep, field: SmdaField) -> SmdaFieldSearchRe
         raise HTTPException(
             status_code=e.response.status_code,
             detail=f"SMDA error requesting {e.request.url!r}",
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         ) from e
     except KeyError as e:
         raise HTTPException(
             status_code=500,
             detail="Malformed response from SMDA: no 'data' field present",
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         ) from e
     except TimeoutError as e:
         raise HTTPException(
             status_code=503,
             detail="SMDA API request timed out. Please try again.",
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         ) from e
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=str(e),
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         ) from e
 
 
@@ -216,7 +216,7 @@ async def post_masterdata(
         raise HTTPException(
             status_code=401,
             detail="SMDA access token is not set",
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         )
 
     # Sorted for tests as sets don't guarantee order
@@ -244,7 +244,9 @@ async def post_masterdata(
             raise HTTPException(
                 status_code=404,
                 detail=f"No fields found for identifiers: {unique_field_identifiers}",
-                headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+                headers={
+                    HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA
+                },
             )
 
         field_items = [FieldItem(**field) for field in field_results]
@@ -278,7 +280,9 @@ async def post_masterdata(
             raise HTTPException(
                 status_code=404,
                 detail="Projected field coordinate system not found",
-                headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+                headers={
+                    HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA
+                },
             )
 
         return SmdaMasterdataResult(
@@ -295,23 +299,23 @@ async def post_masterdata(
         raise HTTPException(
             status_code=e.response.status_code,
             detail=f"SMDA error requesting {e.request.url}",
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         ) from e
     except KeyError as e:
         raise HTTPException(
             status_code=500,
             detail="Malformed response from SMDA: {e}",
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         ) from e
     except Exception as e:
         raise HTTPException(
             status_code=500,
             detail=str(e),
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         ) from e
     except TimeoutError as e:
         raise HTTPException(
             status_code=503,
             detail="SMDA API request timed out. Please try again.",
-            headers={settings.X_UPSTREAM_SOURCE_HEADER_KEY: "SMDA"},
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         ) from e

--- a/tests/test_interfaces/test_smda_api.py
+++ b/tests/test_interfaces/test_smda_api.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from fmu_settings_api.config import HttpHeader
 from fmu_settings_api.interfaces.smda_api import SmdaAPI, SmdaRoutes
 
 
@@ -40,9 +41,9 @@ async def test_smda_get(mock_httpx_get: MagicMock) -> None:
     mock_httpx_get.assert_called_with(
         f"{SmdaRoutes.BASE_URL}/{SmdaRoutes.HEALTH}",
         headers={
-            "Content-Type": "application/json",
-            "authorization": "Bearer token",
-            "Ocp-Apim-Subscription-Key": "key",
+            HttpHeader.CONTENT_TYPE_KEY: HttpHeader.CONTENT_TYPE_JSON,
+            HttpHeader.AUTHORIZATION_KEY: "Bearer token",
+            HttpHeader.OCP_APIM_SUBSCRIPTION_KEY: "key",
         },
     )
     res.raise_for_status.assert_called_once()  # type: ignore
@@ -56,9 +57,9 @@ async def test_smda_post_with_json(mock_httpx_post: MagicMock) -> None:
     mock_httpx_post.assert_called_with(
         f"{SmdaRoutes.BASE_URL}/{SmdaRoutes.HEALTH}",
         headers={
-            "Content-Type": "application/json",
-            "authorization": "Bearer token",
-            "Ocp-Apim-Subscription-Key": "key",
+            HttpHeader.CONTENT_TYPE_KEY: HttpHeader.CONTENT_TYPE_JSON,
+            HttpHeader.AUTHORIZATION_KEY: "Bearer token",
+            HttpHeader.OCP_APIM_SUBSCRIPTION_KEY: "key",
         },
         json={"a": "b"},
     )
@@ -73,9 +74,9 @@ async def test_smda_post_without_json(mock_httpx_post: MagicMock) -> None:
     mock_httpx_post.assert_called_with(
         f"{SmdaRoutes.BASE_URL}/{SmdaRoutes.HEALTH}",
         headers={
-            "Content-Type": "application/json",
-            "authorization": "Bearer token",
-            "Ocp-Apim-Subscription-Key": "key",
+            HttpHeader.CONTENT_TYPE_KEY: HttpHeader.CONTENT_TYPE_JSON,
+            HttpHeader.AUTHORIZATION_KEY: "Bearer token",
+            HttpHeader.OCP_APIM_SUBSCRIPTION_KEY: "key",
         },
         json=None,
     )

--- a/tests/test_v1/test_health.py
+++ b/tests/test_v1/test_health.py
@@ -4,7 +4,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 from fmu_settings_api.__main__ import app
-from fmu_settings_api.config import settings
+from fmu_settings_api.config import HttpHeader
 from fmu_settings_api.models import Ok
 
 client = TestClient(app)
@@ -22,14 +22,14 @@ def test_health_check_no_session() -> None:
 def test_health_check_no_session_bad_token() -> None:
     """Test the health check endpoint with an invalid token but no session."""
     token = "no" * 32
-    response = client.get(ROUTE, headers={settings.TOKEN_HEADER_NAME: token})
+    response = client.get(ROUTE, headers={HttpHeader.API_TOKEN_KEY: token})
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.json()
     assert response.json() == {"detail": "No active session found"}
 
 
 def test_health_check_no_session_valid_token(mock_token: str) -> None:
     """Test the health check endpoint with a valid token but no session."""
-    response = client.get(ROUTE, headers={settings.TOKEN_HEADER_NAME: mock_token})
+    response = client.get(ROUTE, headers={HttpHeader.API_TOKEN_KEY: mock_token})
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.json()
     assert response.json() == {"detail": "No active session found"}
 
@@ -47,9 +47,7 @@ def test_health_check_no_session_valid_session_invalid_token(
 ) -> None:
     """Test the health check endpoint with a valid session and invalid token."""
     token = "no" * 32
-    response = client_with_session.get(
-        ROUTE, headers={settings.TOKEN_HEADER_NAME: token}
-    )
+    response = client_with_session.get(ROUTE, headers={HttpHeader.API_TOKEN_KEY: token})
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json() == {"status": "ok"}
     assert Ok() == Ok.model_validate(response.json())
@@ -60,7 +58,7 @@ def test_health_check_no_session_valid_session_valid_token(
 ) -> None:
     """Test the health check endpoint with a valid session and valid token."""
     response = client_with_session.get(
-        ROUTE, headers={settings.TOKEN_HEADER_NAME: mock_token}
+        ROUTE, headers={HttpHeader.API_TOKEN_KEY: mock_token}
     )
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json() == {"status": "ok"}

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -12,7 +12,7 @@ from fmu.settings._init import init_fmu_directory
 from pytest import MonkeyPatch
 
 from fmu_settings_api.__main__ import app
-from fmu_settings_api.config import settings
+from fmu_settings_api.config import HttpHeader, settings
 from fmu_settings_api.models.project import FMUProject
 from fmu_settings_api.session import ProjectSession, Session
 
@@ -30,11 +30,11 @@ def test_get_project_does_not_care_about_token(mock_token: str) -> None:
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "No active session found"}
 
-    response = client.get(ROUTE, headers={settings.TOKEN_HEADER_NAME: mock_token})
+    response = client.get(ROUTE, headers={HttpHeader.API_TOKEN_KEY: mock_token})
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "No active session found"}
 
-    response = client.get(ROUTE, headers={settings.TOKEN_HEADER_NAME: "no" * 32})
+    response = client.get(ROUTE, headers={HttpHeader.API_TOKEN_KEY: "no" * 32})
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": "No active session found"}
 

--- a/tests/test_v1/test_smda.py
+++ b/tests/test_v1/test_smda.py
@@ -16,6 +16,7 @@ from fmu.settings.models.smda import (
     StratigraphicColumn,
 )
 
+from fmu_settings_api.config import HttpHeader
 from fmu_settings_api.models.smda import (
     SmdaFieldSearchResult,
     SmdaFieldUUID,
@@ -46,7 +47,10 @@ def test_get_health(client_with_session: TestClient, session_tmp_path: Path) -> 
     """Test 401 returns when the user has no SMDA API key set in their configuration."""
     response = client_with_session.get(f"{ROUTE}/health")
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.json()
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     assert response.json()["detail"] == "User SMDA API key is not configured"
 
 
@@ -65,7 +69,10 @@ def test_get_health_has_user_api_key(
 
     response = client_with_session.get(f"{ROUTE}/health")
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.json()
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     assert response.json()["detail"] == "SMDA access token is not set"
 
 
@@ -83,7 +90,10 @@ async def test_get_health_has_user_api_key_and_access_token(
 
     response = client_with_smda_session.get(f"{ROUTE}/health")
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     assert response.json()["status"] == "ok"
 
 
@@ -106,7 +116,10 @@ async def test_get_health_request_failure_raises_exception(
     response = client_with_smda_session.get(f"{ROUTE}/health")
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.json()
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     assert response.json()["detail"] == "SMDA error requesting https://smda"
 
 
@@ -138,7 +151,10 @@ async def test_post_field_succeeds_with_one(
         f"{ROUTE}/field", json={"identifier": "TROLL"}
     )
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     assert SmdaFieldSearchResult.model_validate(
         response.json()
     ) == SmdaFieldSearchResult(
@@ -173,7 +189,10 @@ async def test_post_field_succeeds_with_none(
     )
 
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     assert SmdaFieldSearchResult.model_validate(
         response.json()
     ) == SmdaFieldSearchResult(
@@ -203,7 +222,10 @@ async def test_post_field_with_no_identifier_raises(
     response = client_with_smda_session.post(f"{ROUTE}/field", json={"identifier": ""})
 
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     assert SmdaFieldSearchResult.model_validate(
         response.json()
     ) == SmdaFieldSearchResult(
@@ -229,7 +251,10 @@ async def test_post_field_has_bad_response_raises(
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, (
         response.json()
     )
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     assert (
         response.json()["detail"]
         == "Malformed response from SMDA: no 'data' field present"
@@ -326,7 +351,10 @@ async def test_post_masterdata_success(
         )
 
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     response_data = response.json()
     assert len(response_data["field"]) == 1
     assert response_data["field"][0]["identifier"] == "DROGON"
@@ -407,7 +435,10 @@ async def test_post_masterdata_missing_coordinate_system(
         )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     assert "Projected field coordinate system not found" in response.json()["detail"]
 
 
@@ -434,7 +465,10 @@ async def test_post_masterdata_malformed_response(
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, (
         response.json()
     )
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     assert "Malformed response from SMDA" in response.json()["detail"]
 
 
@@ -510,7 +544,10 @@ async def test_post_masterdata_multiple_fields(
         )
 
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     response_data = response.json()
     assert len(response_data["field"]) == 2  # noqa
 
@@ -597,5 +634,8 @@ async def test_post_masterdata_request_fails(
     )
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.json()
-    assert response.headers["x-upstream-source"] == "SMDA"
+    assert (
+        response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
+        == HttpHeader.UPSTREAM_SOURCE_SMDA
+    )
     assert response.json()["detail"] == "SMDA error requesting https://smda"


### PR DESCRIPTION
Resolves #86 

Added new `HttpHeader` enum to be used for fixed header values. Updated the code to use the header values from the enum instead of hard coded strings.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
