### PR TITLE
FIX: Import models from fmu.datamodels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "fastapi",
+    "fmu.datamodels",
     "fmu-settings",
     "httpx",
     "pydantic",

--- a/src/fmu_settings_api/models/smda.py
+++ b/src/fmu_settings_api/models/smda.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from fmu.settings.models.smda import (
+from fmu.datamodels.fmu_results.fields import (
     CoordinateSystem,
     CountryItem,
     DiscoveryItem,

--- a/src/fmu_settings_api/services/smda.py
+++ b/src/fmu_settings_api/services/smda.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 
-from fmu.settings.models.smda import (
+from fmu.datamodels.fmu_results.fields import (
     CoordinateSystem,
     CountryItem,
     DiscoveryItem,

--- a/src/fmu_settings_api/v1/routes/smda/main.py
+++ b/src/fmu_settings_api/v1/routes/smda/main.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Response
-from fmu.settings.models.smda import (
+from fmu.datamodels.fmu_results.fields import (
     CoordinateSystem,
     FieldItem,
 )

--- a/tests/test_services/test_smda_service.py
+++ b/tests/test_services/test_smda_service.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
 import pytest
-from fmu.settings.models.smda import (
+from fmu.datamodels.fmu_results.fields import (
     CoordinateSystem,
     CountryItem,
     DiscoveryItem,

--- a/tests/test_v1/test_smda.py
+++ b/tests/test_v1/test_smda.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
-from fmu.settings.models.smda import (
+from fmu.datamodels.fmu_results.fields import (
     CoordinateSystem,
     CountryItem,
     DiscoveryItem,


### PR DESCRIPTION
Resolves #92

PR to fix failing import. Changed to import relevant `smda` models from `fmu-datamodels` instead of `fmu-settings`. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
