### PR TITLE
ENH: Add project route to save masterdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ fmu-settings api --print-token
 It's useful to be able to reload while developing.
 
 ```sh
-fmu-settings-api --print-token --reload
+fmu-settings api --print-token --reload
 ```
 
 ## API Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "fastapi",
-    "fmu.datamodels",
+    "fmu-datamodels",
     "fmu-settings",
     "httpx",
     "pydantic",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import stat
 from collections.abc import AsyncGenerator, Callable, Generator, Iterator
 from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -149,3 +150,30 @@ async def client_with_smda_session(session_id: str) -> AsyncGenerator[TestClient
 def session_tmp_path() -> Path:
     """Returns the tmp_path equivalent from a mocked user .fmu dir."""
     return UserFMUDirectory().path.parent.parent
+
+
+@pytest.fixture
+def smda_masterdata() -> dict[str, Any]:
+    """Returns an example SMDA masterdata for the .fmu project."""
+    return {
+        "stratigraphic_column": {
+            "identifier": "DROGON_2020",
+            "uuid": "15ce3b84-766f-4c93-9050-b154861f9100",
+        },
+        "coordinate_system": {
+            "identifier": "ST_WGS84_UTM37N_P32637",
+            "uuid": "15ce3b84-766f-4c93-9050-b154861f9100",
+        },
+        "country": [
+            {"identifier": "Norway", "uuid": "15ce3b84-766f-4c93-9050-b154861f9100"}
+        ],
+        "discovery": [
+            {
+                "short_identifier": "SomeDiscovery",
+                "uuid": "15ce3b84-766f-4c93-9050-b154861f9100",
+            }
+        ],
+        "field": [
+            {"identifier": "OseFax", "uuid": "15ce3b84-766f-4c93-9050-b154861f9100"}
+        ],
+    }

--- a/tests/test_services/test_smda_service.py
+++ b/tests/test_services/test_smda_service.py
@@ -106,7 +106,6 @@ async def test_get_discoveries(given: list[str], mock_val: list[DiscoveryItem]) 
         }
         for i, item in enumerate(mock_val)
     ]
-    print(results)
     discovery_resp.json.return_value = {"data": {"results": results}}
     mock_smda.discovery.return_value = discovery_resp
 


### PR DESCRIPTION
Resolves #82 

PR to add a new endpoint for saving the `SMDA` masterdata to the project .fmu.
This endpoint requires a project session.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
