### PR TITLE
MAINT: Make SmdaAPI an injected dependency

### DIFF
--- a/src/fmu_settings_api/deps.py
+++ b/src/fmu_settings_api/deps.py
@@ -8,6 +8,7 @@ from fmu.settings._fmu_dir import UserFMUDirectory
 from fmu.settings._init import init_user_fmu_directory
 
 from fmu_settings_api.config import HttpHeader, settings
+from fmu_settings_api.interfaces.smda_api import SmdaAPI
 from fmu_settings_api.session import (
     ProjectSession,
     Session,
@@ -155,3 +156,36 @@ async def get_project_smda_session(
 
 
 ProjectSmdaSessionDep = Annotated[ProjectSession, Depends(get_project_smda_session)]
+
+
+async def get_smda_api(session: Session | ProjectSession) -> SmdaAPI:
+    """Returns an Smda api object for the given session."""
+    if session.access_tokens.smda_api is None:
+        raise HTTPException(
+            status_code=401,
+            detail="SMDA access token is not set",
+            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
+        )
+
+    return SmdaAPI(
+        access_token=session.access_tokens.smda_api.get_secret_value(),
+        subscription_key=session.user_fmu_directory.get_config_value(
+            "user_api_keys.smda_subscription"
+        ).get_secret_value(),
+    )
+
+
+async def get_smda_interface(session: SessionDep) -> SmdaAPI:
+    """Returns an Smda interface for the .fmu session."""
+    return await get_smda_api(session)
+
+
+SmdaInterfaceDep = Annotated[SmdaAPI, Depends(get_smda_interface)]
+
+
+async def get_project_smda_interface(session: ProjectSmdaSessionDep) -> SmdaAPI:
+    """Returns an Smda interface for the project .fmu session."""
+    return await get_smda_api(session)
+
+
+ProjectSmdaInterfaceDep = Annotated[SmdaAPI, Depends(get_project_smda_interface)]

--- a/tests/test_v1/test_deps.py
+++ b/tests/test_v1/test_deps.py
@@ -1,17 +1,25 @@
 """Tests dependencies (middleware)."""
 
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import create_autospec, patch
 from uuid import uuid4
 
 import pytest
 from fastapi import Cookie, HTTPException, status
 from fastapi.testclient import TestClient
 from fmu.settings._init import init_user_fmu_directory
+from pydantic import SecretStr
 
 from fmu_settings_api.config import settings
-from fmu_settings_api.deps import get_session
-from fmu_settings_api.session import SessionManager
+from fmu_settings_api.deps import (
+    ProjectSmdaSessionDep,
+    SmdaInterfaceDep,
+    get_project_smda_interface,
+    get_session,
+)
+from fmu_settings_api.interfaces.smda_api import SmdaAPI
+from fmu_settings_api.session import AccessTokens, SessionManager
 
 ROUTE = "/api/v1/health"
 
@@ -48,3 +56,69 @@ def test_get_session_dep_from_request(
     client_with_session.cookies.set(settings.SESSION_COOKIE_KEY, str(uuid4()))
     response = client_with_session.get(ROUTE)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.json()
+
+
+async def test_get_smda_interface(tmp_path_mocked_home: Path) -> None:
+    """Tests the get_smda_interface dependency."""
+    smda_api_token_mock = "test_token"
+    smda_subscription_mock = "test_subscription"
+    user_fmu_directory = init_user_fmu_directory()
+    user_fmu_directory.set_config_value(
+        "user_api_keys.smda_subscription", smda_subscription_mock
+    )
+
+    session_mock = create_autospec(SmdaInterfaceDep, instance=True)
+    session_mock.id = str(uuid4())
+    session_mock.created_at = datetime.now(UTC)
+    session_mock.expires_at = timedelta(seconds=60)
+    session_mock.last_accessed = datetime.now(UTC)
+    session_mock.access_tokens = AccessTokens(
+        fmu_settings=SecretStr("fmu_settings_token")
+    )
+    session_mock.user_fmu_directory = user_fmu_directory
+
+    with pytest.raises(HTTPException, match="401: SMDA access token is not set"):
+        await get_project_smda_interface(session_mock)
+
+    session_mock.access_tokens = AccessTokens(
+        fmu_settings=SecretStr("fmu_settings_token"),
+        smda_api=SecretStr(smda_api_token_mock),
+    )
+
+    smda_project_interface: SmdaAPI = await get_project_smda_interface(session_mock)
+    assert isinstance(smda_project_interface, SmdaAPI)
+    assert smda_project_interface._access_token == smda_api_token_mock
+    assert smda_project_interface._subscription_key == smda_subscription_mock
+
+
+async def test_get_project_smda_interface(tmp_path_mocked_home: Path) -> None:
+    """Tests the get_project_smda_interface dependency."""
+    smda_api_token_mock = "test_token"
+    smda_subscription_mock = "test_subscription"
+    user_fmu_directory = init_user_fmu_directory()
+    user_fmu_directory.set_config_value(
+        "user_api_keys.smda_subscription", smda_subscription_mock
+    )
+
+    project_session_mock = create_autospec(ProjectSmdaSessionDep, instance=True)
+    project_session_mock.id = str(uuid4())
+    project_session_mock.created_at = datetime.now(UTC)
+    project_session_mock.expires_at = timedelta(seconds=60)
+    project_session_mock.last_accessed = datetime.now(UTC)
+    project_session_mock.access_tokens = AccessTokens(
+        fmu_settings=SecretStr("fmu_settings_token")
+    )
+    project_session_mock.user_fmu_directory = user_fmu_directory
+
+    with pytest.raises(HTTPException, match="401: SMDA access token is not set"):
+        await get_project_smda_interface(project_session_mock)
+
+    project_session_mock.access_tokens = AccessTokens(
+        fmu_settings=SecretStr("fmu_settings_token"),
+        smda_api=SecretStr(smda_api_token_mock),
+    )
+
+    smda_interface = await get_project_smda_interface(project_session_mock)
+    assert isinstance(smda_interface, SmdaAPI)
+    assert smda_interface._access_token == smda_api_token_mock
+    assert smda_interface._subscription_key == smda_subscription_mock

--- a/tests/test_v1/test_smda.py
+++ b/tests/test_v1/test_smda.py
@@ -28,9 +28,7 @@ ROUTE = "/api/v1/smda"
 @pytest.fixture
 async def mock_SmdaAPI_get() -> AsyncGenerator[AsyncMock]:
     """Mocks the get() method on SmdaAPI."""
-    with patch(
-        "fmu_settings_api.v1.routes.smda.main.SmdaAPI.get", new_callable=AsyncMock
-    ) as get_mock:
+    with patch("fmu_settings_api.deps.SmdaAPI.get", new_callable=AsyncMock) as get_mock:
         yield get_mock
 
 
@@ -38,7 +36,7 @@ async def mock_SmdaAPI_get() -> AsyncGenerator[AsyncMock]:
 async def mock_SmdaAPI_post() -> AsyncGenerator[AsyncMock]:
     """Mocks the post() method on SmdaAPI."""
     with patch(
-        "fmu_settings_api.v1.routes.smda.main.SmdaAPI.post", new_callable=AsyncMock
+        "fmu_settings_api.deps.SmdaAPI.post", new_callable=AsyncMock
     ) as post_mock:
         yield post_mock
 
@@ -303,7 +301,7 @@ async def test_post_masterdata_success(
     }
 
     with (
-        patch("fmu_settings_api.v1.routes.smda.main.SmdaAPI") as mock_smda_class,
+        patch("fmu_settings_api.deps.SmdaAPI") as mock_smda_class,
         patch(
             "fmu_settings_api.v1.routes.smda.main.get_coordinate_systems",
             new_callable=AsyncMock,
@@ -397,7 +395,7 @@ async def test_post_masterdata_missing_coordinate_system(
     }
 
     with (
-        patch("fmu_settings_api.v1.routes.smda.main.SmdaAPI") as mock_smda_class,
+        patch("fmu_settings_api.deps.SmdaAPI") as mock_smda_class,
         patch(
             "fmu_settings_api.v1.routes.smda.main.get_coordinate_systems",
             new_callable=AsyncMock,
@@ -453,7 +451,7 @@ async def test_post_masterdata_malformed_response(
         "malformed": "response",
     }
 
-    with patch("fmu_settings_api.v1.routes.smda.main.SmdaAPI") as mock_smda_class:
+    with patch("fmu_settings_api.deps.SmdaAPI") as mock_smda_class:
         mock_smda_instance = AsyncMock()
         mock_smda_instance.field.return_value = mock_field_response
         mock_smda_class.return_value = mock_smda_instance
@@ -501,7 +499,7 @@ async def test_post_masterdata_multiple_fields(
     }
 
     with (
-        patch("fmu_settings_api.v1.routes.smda.main.SmdaAPI") as mock_smda_class,
+        patch("fmu_settings_api.deps.SmdaAPI") as mock_smda_class,
         patch(
             "fmu_settings_api.v1.routes.smda.main.get_coordinate_systems",
             new_callable=AsyncMock,
@@ -578,7 +576,7 @@ async def test_post_masterdata_empty_field_list(
     }
 
     with (
-        patch("fmu_settings_api.v1.routes.smda.main.SmdaAPI") as mock_smda_class,
+        patch("fmu_settings_api.deps.SmdaAPI") as mock_smda_class,
         patch(
             "fmu_settings_api.v1.routes.smda.main.get_coordinate_systems",
             new_callable=AsyncMock,


### PR DESCRIPTION
Resolves #79

Creating an instance of the SmdaApi, in addition to checking if the conditions for creating an instance of SmdaAPI are met, is now made a dependency that can is injected into the routes, instead of having each of the routes to implement this logic. 

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
