### PR TITLE
ENH: Add endpoint to load global_config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "fastapi",
+    "fmu-config",
     "fmu-datamodels",
     "fmu-settings",
     "httpx",

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -5,15 +5,19 @@ from textwrap import dedent
 from typing import Final
 
 from fastapi import APIRouter, HTTPException, Response
+from fmu.config import utilities
+from fmu.datamodels.fmu_results import global_configuration
 from fmu.datamodels.fmu_results.fields import Smda
 from fmu.settings import find_nearest_fmu_directory, get_fmu_directory
 from fmu.settings._init import init_fmu_directory
+from pydantic import ValidationError
 
 from fmu_settings_api.deps import (
     ProjectSessionDep,
     SessionDep,
 )
 from fmu_settings_api.models import FMUDirPath, FMUProject, Message
+from fmu_settings_api.models.common import Ok
 from fmu_settings_api.session import (
     ProjectSession,
     SessionNotFoundError,
@@ -26,6 +30,7 @@ from fmu_settings_api.v1.responses import (
     inline_add_response,
 )
 
+GLOBAL_CONFIG_DEFAULT_PATH: Final[Path] = Path("fmuconfig/output/global_variables.yml")
 router = APIRouter(prefix="/project", tags=["project"])
 
 ProjectResponses: Final[Responses] = {
@@ -223,6 +228,57 @@ async def init_project(
         raise HTTPException(
             status_code=409, detail=f".fmu already exists at {path}"
         ) from e
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post(
+    "/global_config",
+    response_model=Ok,
+    summary=("Loads the global config into the project masterdata."),
+    description=dedent(
+        """
+        Loads the global config into the project masterdata. If the
+        global config does not validate, or is not found, a failed status code is
+        returned. The global config is searched for at the default project path,
+        or at the path provided as a parameter in the request.
+       """
+    ),
+    responses={
+        **GetSessionResponses,
+        **ProjectResponses,
+        **ProjectExistsResponses,
+    },
+)
+async def load_global_config(
+    project_session: ProjectSessionDep, global_config_path: Path | None = None
+) -> Ok:
+    """Loads the global config into the project masterdata if found and valid."""
+    try:
+        fmu_dir = project_session.project_fmu_directory
+        mode = "provided"
+        if global_config_path is None:
+            project_path = fmu_dir.get_file_path(
+                fmu_dir.config.relative_path
+            ).parent.parent
+            global_config_path = project_path / GLOBAL_CONFIG_DEFAULT_PATH
+            mode = "default"
+
+        if not global_config_path.exists():
+            raise FileExistsError(
+                f"Could not find the global_variables.yml file at the {mode} path."
+            )
+
+        global_config_dict = utilities.yaml_load(global_config_path)
+        global_config = global_configuration.GlobalConfiguration.model_validate(
+            global_config_dict
+        )
+        fmu_dir.set_config_value("masterdata", global_config.masterdata.model_dump())
+        return Ok()
+    except FileExistsError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except ValidationError as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -177,3 +177,54 @@ def smda_masterdata() -> dict[str, Any]:
             {"identifier": "OseFax", "uuid": "15ce3b84-766f-4c93-9050-b154861f9100"}
         ],
     }
+
+
+@pytest.fixture
+def global_variables_mock() -> dict[str, Any]:
+    """Returns an example of the global_variables.yml file with smda masterdata."""
+    return {
+        "masterdata": {
+            "smda": {
+                "stratigraphic_column": {
+                    "identifier": "DROGON_2020",
+                    "uuid": "15ce3b84-766f-4c93-9050-b154861f9100",
+                },
+                "coordinate_system": {
+                    "identifier": "ST_WGS84_UTM37N_P32637",
+                    "uuid": "15ce3b84-766f-4c93-9050-b154861f9100",
+                },
+                "country": [
+                    {
+                        "identifier": "Norway",
+                        "uuid": "15ce3b84-766f-4c93-9050-b154861f9100",
+                    }
+                ],
+                "discovery": [
+                    {
+                        "short_identifier": "SomeDiscovery",
+                        "uuid": "15ce3b84-766f-4c93-9050-b154861f9100",
+                    }
+                ],
+                "field": [
+                    {
+                        "identifier": "OseFax",
+                        "uuid": "15ce3b84-766f-4c93-9050-b154861f9100",
+                    }
+                ],
+            }
+        },
+        "access": {"asset": {"name": "Drogon"}, "classification": "internal"},
+        "model": {"name": "ff", "revision": "21.1.0.dev"},
+        "stratigraphy": {
+            "MSL": {"stratigraphic": False, "name": "MSL"},
+            "Seabase": {"stratigraphic": False, "name": "Seabase"},
+            "TopTherys": {"stratigraphic": True, "name": "Therys Fm. Top"},
+        },
+        "global": {"GLOBAL_VARS_EXAMPLE": 99, "OTHER": "skipped"},
+        "rms": {
+            "horizons": {
+                "TOP_RES": ["TopVolantis", "TopTherys", "TopVolon", "BaseVolantis"]
+            },
+            "zones": {"ZONE_RES": ["Valysar", "Therys", "Volon"]},
+        },
+    }

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -1,11 +1,13 @@
 """Tests the /api/v1/project routes."""
 
+import json
 import shutil
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
+from uuid import UUID
 
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -572,3 +574,165 @@ def test_patch_masterdata_no_directory(
     assert get_fmu_project.config.masterdata.smda == Smda.model_validate(
         smda_masterdata
     )
+
+
+def test_load_global_config_from_default_path(
+    client_with_project_session: TestClient,
+    session_tmp_path: Path,
+    global_variables_mock: dict[str, Any],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Test loading masterdata from the default global variables path.
+
+    When a valid global_variables file exists at the default path and
+    no custom path is provided in the request, loading masterdata from
+    the global config into the project masterdata should be sucessfull.
+    """
+    # Get project session and check that masterdata is not set
+    get_response = client_with_project_session.get(ROUTE)
+    fmu_project = FMUProject.model_validate(get_response.json())
+    assert fmu_project.config.masterdata is None
+
+    # Create fmuconfig folders at default path
+    relative_path = Path("fmuconfig/output/")
+    monkeypatch.chdir(session_tmp_path)
+    global_config_default_folder = session_tmp_path / relative_path
+    global_config_default_folder.mkdir(parents=True, exist_ok=True)
+
+    # Write the global_variables mock to the default location
+    global_config_path = global_config_default_folder / Path("global_variables.yml")
+    with open(global_config_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(global_variables_mock, indent=2, sort_keys=True))
+
+    # Do the post request and check that it response is OK
+    response = client_with_project_session.post(f"{ROUTE}/global_config/")
+    assert response.status_code == status.HTTP_200_OK
+
+    # Get project data and check that masterdata has been set
+    get_response = client_with_project_session.get(ROUTE)
+    fmu_project = FMUProject.model_validate(get_response.json())
+    expected_field_uuid = UUID(
+        global_variables_mock["masterdata"]["smda"]["field"][0]["uuid"]
+    )
+    expected_field_identifier = global_variables_mock["masterdata"]["smda"]["field"][0][
+        "identifier"
+    ]
+    expected_smda_country = global_variables_mock["masterdata"]["smda"]["country"][0][
+        "identifier"
+    ]
+
+    assert fmu_project.config.masterdata is not None
+    assert fmu_project.config.masterdata.smda.field[0].uuid == expected_field_uuid
+    assert (
+        fmu_project.config.masterdata.smda.field[0].identifier
+        == expected_field_identifier
+    )
+    assert (
+        fmu_project.config.masterdata.smda.country[0].identifier
+        == expected_smda_country
+    )
+
+
+def test_load_global_config_from_provided_path(
+    client_with_project_session: TestClient,
+    session_tmp_path: Path,
+    global_variables_mock: dict[str, Any],
+) -> None:
+    """Test loading masterdata from a provided global variables path.
+
+    When a valid global_variables file exists at the path
+    provided in the request, loading masterdata from
+    the global config into the project masterdata should be sucessfull.
+    """
+    # Get project session and check that masterdata is not set
+    get_response = client_with_project_session.get(ROUTE)
+    fmu_project = FMUProject.model_validate(get_response.json())
+    assert fmu_project.config.masterdata is None
+
+    # Write the global_variables mock to a custom path
+    global_config_path = session_tmp_path / Path("global_variables.yml")
+    with open(global_config_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(global_variables_mock, indent=2, sort_keys=True))
+
+    # Do the post request and check that response is OK
+    response = client_with_project_session.post(
+        f"{ROUTE}/global_config/?global_config_path={global_config_path}"
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    # Get project data and check that masterdata has been set
+    get_response = client_with_project_session.get(ROUTE)
+    fmu_project = FMUProject.model_validate(get_response.json())
+    expected_field_uuid = UUID(
+        global_variables_mock["masterdata"]["smda"]["field"][0]["uuid"]
+    )
+    expected_field_identifier = global_variables_mock["masterdata"]["smda"]["field"][0][
+        "identifier"
+    ]
+    expected_smda_country = global_variables_mock["masterdata"]["smda"]["country"][0][
+        "identifier"
+    ]
+
+    assert fmu_project.config.masterdata is not None
+    assert fmu_project.config.masterdata.smda.field[0].uuid == expected_field_uuid
+    assert (
+        fmu_project.config.masterdata.smda.field[0].identifier
+        == expected_field_identifier
+    )
+    assert (
+        fmu_project.config.masterdata.smda.country[0].identifier
+        == expected_smda_country
+    )
+
+
+def test_load_global_config_file_not_found(
+    client_with_project_session: TestClient, session_tmp_path: Path
+) -> None:
+    """Test 404 is returned when no file is found."""
+    mode = "default"
+    response = client_with_project_session.post(f"{ROUTE}/global_config/")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {
+        "detail": f"Could not find the global_variables.yml file at the {mode} path."
+    }
+
+    mode = "provided"
+    global_config_path = session_tmp_path / Path("global_variables.yml")
+    response = client_with_project_session.post(
+        f"{ROUTE}/global_config/?global_config_path={global_config_path}"
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {
+        "detail": f"Could not find the global_variables.yml file at the {mode} path."
+    }
+
+
+def test_load_global_config_invalid_model(
+    client_with_project_session: TestClient,
+    session_tmp_path: Path,
+    global_variables_mock: dict[str, Any],
+) -> None:
+    """Test 500 returned when the data in global_variables is invalid."""
+    del global_variables_mock["masterdata"]
+    global_config_path = session_tmp_path / Path("global_variables.yml")
+    with open(global_config_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(global_variables_mock, indent=2, sort_keys=True))
+
+    response = client_with_project_session.post(
+        f"{ROUTE}/global_config/?global_config_path={global_config_path}"
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert "validation error for GlobalConfiguration" in str(response.json())
+
+
+def test_load_global_config_with_no_project_session(
+    client_with_session: TestClient,
+) -> None:
+    """Test 401 returned when user does not have a project session."""
+    response = client_with_session.post(f"{ROUTE}/global_config/")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": "No FMU project directory open"}


### PR DESCRIPTION
Resolves #89 

Add endpoint to import global config from `global_variables.yml` into the project config. In this first iteration only the masterdata is loaded into the project masterdata.

The endpoint accepts and optional path as input. If the path is not set, the endpoint will look for the `global_variables.yml` file at the default location `<project_root>/fmuconfig/output/global_variables.yml`. If a path is provided as a parameter in the request, the endpoint will look for the `global_variables.yml` file at the provided path.

* If the `global_variables.yml` file is not found, a 404 status code is returned with a descriptional message.
* If the `global_variables.yml` file does not validate agains the Pydantic model GlobalConfiguration, a 500 status code is returned with the validation error message. 
* If the user does not have a project session, a 401 status code is retuned (from the injected dependency ProjectSessionDep).
 

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
