### PR TITLE
ENH: Add endpoint to get global config status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "fastapi",
-    "fmu-config",
     "fmu-datamodels",
     "fmu-settings",
     "httpx",
     "pydantic",
+    "pyyaml",
     "uvicorn",
 ]
 
@@ -47,6 +47,7 @@ dev = [
     "pytest-mock",
     "pytest-xdist",
     "ruff",
+    "types-PyYAML",
     "types-requests",
     "watchfiles",
 ]


### PR DESCRIPTION
Resolves #100 

A new GET endpoint `/global_config_status` has been added under the `/project` route. The endpoint checks if a file is present at the global config default project location `fmuconfig/output/global_variables.yml` and validates the content. If the file exists and validates, `Ok` is returned. If not:
* If the file is not found at the default project location a `404` status code is returned together with an error message stating at which path the file was not found.
* If the file does not validate a `422` status code is returned together with an error message including the validation error.

Also replaced the function `utilities.yaml_load()` from `fmu-config` with `yaml.safe_load()`. In this way we can remove the dependency `fmu-config`. We might need it later if we implement a resource manager in `fmu-config`, but for no we dont need that extra dependency.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
