### PR TITLE
ENH: Start adding to user recent projects

### DIFF
--- a/src/fmu_settings_api/services/user.py
+++ b/src/fmu_settings_api/services/user.py
@@ -1,0 +1,23 @@
+"""Functions for interacting with the user .fmu directory."""
+
+from pathlib import Path
+
+from fmu.settings._fmu_dir import UserFMUDirectory
+
+
+def add_to_user_recent_projects(
+    project_path: Path,
+    user_dir: UserFMUDirectory,
+) -> None:
+    """Adds a project path to the user's recent project directories.
+
+    Existing paths will be moved to the end if re-added.
+    Only the last 5 recent projects are kept.
+    """
+    recent_projects = user_dir.get_config_value("recent_project_directories")
+
+    if project_path in recent_projects:
+        recent_projects.remove(project_path)
+
+    recent_projects.append(project_path)
+    user_dir.set_config_value("recent_project_directories", recent_projects[-5:])

--- a/src/fmu_settings_api/session.py
+++ b/src/fmu_settings_api/session.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, SecretStr
 
 from fmu_settings_api.config import settings
 from fmu_settings_api.models.common import AccessToken
+from fmu_settings_api.services.user import add_to_user_recent_projects
 
 
 class SessionNotFoundError(ValueError):
@@ -173,6 +174,10 @@ async def add_fmu_project_to_session(
         project_session = ProjectSession(
             **asdict(session), project_fmu_directory=project_fmu_directory
         )
+    add_to_user_recent_projects(
+        project_path=project_fmu_directory.base_path,
+        user_dir=project_session.user_fmu_directory,
+    )
     await session_manager._store_session(session_id, project_session)
     return project_session
 

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -1,0 +1,71 @@
+"""Tests the user service functions."""
+
+from pathlib import Path
+
+import pytest
+from fmu.settings._init import init_user_fmu_directory
+
+from fmu_settings_api.services.user import add_to_user_recent_projects
+
+
+def test_add_to_user_recent_projects(tmp_path_mocked_home: Path) -> None:
+    """Tests adding to recent projects works as expected."""
+    user_dir = init_user_fmu_directory()
+
+    # Initially empty
+    assert user_dir.get_config_value("recent_project_directories") == []
+
+    project_path = Path("/some/project")
+    add_to_user_recent_projects(project_path, user_dir)
+    assert user_dir.get_config_value("recent_project_directories") == [project_path]
+
+    # add yet another project
+    new_project_path = Path("/new/project")
+    add_to_user_recent_projects(new_project_path, user_dir)
+    assert user_dir.get_config_value("recent_project_directories") == [
+        project_path,
+        new_project_path,
+    ]
+
+
+def test_add_to_user_recent_projects_does_not_add_duplicate(
+    tmp_path_mocked_home: Path,
+) -> None:
+    """Tests adding to recent projects does not add duplicates."""
+    user_dir = init_user_fmu_directory()
+    project_path = Path("/some/project")
+
+    # call it twice
+    add_to_user_recent_projects(project_path, user_dir)
+    add_to_user_recent_projects(project_path, user_dir)
+    assert user_dir.get_config_value("recent_project_directories") == [project_path]
+
+
+def test_add_to_user_recent_projects_removes_oldest_when_full(
+    tmp_path_mocked_home: Path,
+) -> None:
+    """Tests adding to recent projects does not exceed max limit."""
+    user_dir = init_user_fmu_directory()
+    max_number_of_recent_projects = 5
+
+    project_paths = [
+        Path(f"/project/{i}") for i in range(max_number_of_recent_projects)
+    ]
+    user_dir.set_config_value("recent_project_directories", project_paths)
+    assert len(project_paths) == max_number_of_recent_projects
+
+    # add a new project and check that the length
+    # is still 5 and the oldest is removed
+    new_path = Path("/project/new")
+    expected_recent_projects = project_paths[1:] + [new_path]
+    add_to_user_recent_projects(new_path, user_dir)
+    recent_projects = user_dir.get_config_value("recent_project_directories")
+    assert recent_projects == expected_recent_projects
+    assert len(recent_projects) == max_number_of_recent_projects
+
+    # directly set the value to more than 5
+    # should fail unless length requirement in fmu-settings is changed
+    with pytest.raises(ValueError):
+        user_dir.set_config_value(
+            "recent_project_directories", [Path(f"/project/{i}") for i in range(6)]
+        )


### PR DESCRIPTION
Resolves #103 

PR to start adding a selected project to the `recent_project_directories` in the user config.

Note this requires an unreleased change in `fmu-settings` where `recent_project_directories` are changed to a list.
Hence the CI failures

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
