### PR TITLE
ENH: Improve post project response when path does not exist

### DIFF
--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -235,6 +235,9 @@ async def get_global_config_status(project_session: ProjectSessionDep) -> Ok:
 async def post_project(session: SessionDep, fmu_dir_path: FMUDirPath) -> FMUProject:
     """Returns the paths and configuration for the project .fmu directory at 'path'."""
     path = fmu_dir_path.path
+    if not path.exists():
+        raise HTTPException(status_code=404, detail=f"Path {path} does not exist")
+
     try:
         fmu_dir = get_fmu_directory(path)
         await add_fmu_project_to_session(session.id, fmu_dir)

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -320,6 +320,14 @@ def test_post_project_directory_corrupt(
     )
 
 
+def test_post_project_directory_not_exists(client_with_session: TestClient) -> None:
+    """Test 404 returns with proper message when path does not exists."""
+    path = Path("/non/existing/path")
+    response = client_with_session.post(ROUTE, json={"path": str(path)})
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == f"Path {path} does not exist"
+
+
 def test_post_fmu_directory_raises_other_exceptions(
     client_with_session: TestClient,
 ) -> None:


### PR DESCRIPTION
Resolves #101 

PR to separate the 404 detail message for when a proposed project path is non-existing and for when the `.fmu` within that directory is missing.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
