### PR TITLE
ENH: Reverse the order of recent_project_directories

### DIFF
--- a/src/fmu_settings_api/services/user.py
+++ b/src/fmu_settings_api/services/user.py
@@ -11,16 +11,17 @@ def add_to_user_recent_projects(
 ) -> None:
     """Adds a project path to the user's recent project directories.
 
-    Existing paths will be moved to the end if re-added.
-    Only the last 5 recent projects are kept.
+    The directories are ordered with the most recent project first in the list.
+    Existing paths will be moved to the start if re-added.
+    Only the 5 most recent projects are kept.
     """
     recent_projects = user_dir.get_config_value("recent_project_directories")
 
     if project_path in recent_projects:
         recent_projects.remove(project_path)
 
-    recent_projects.append(project_path)
-    user_dir.set_config_value("recent_project_directories", recent_projects[-5:])
+    recent_projects.insert(0, project_path)
+    user_dir.set_config_value("recent_project_directories", recent_projects[:5])
 
 
 def remove_from_recent_projects(
@@ -32,4 +33,4 @@ def remove_from_recent_projects(
 
     if project_path in recent_projects:
         recent_projects.remove(project_path)
-        user_dir.set_config_value("recent_project_directories", recent_projects[-5:])
+        user_dir.set_config_value("recent_project_directories", recent_projects)

--- a/tests/test_services/test_user_service.py
+++ b/tests/test_services/test_user_service.py
@@ -22,12 +22,12 @@ def test_add_to_user_recent_projects(tmp_path_mocked_home: Path) -> None:
     add_to_user_recent_projects(project_path, user_dir)
     assert user_dir.get_config_value("recent_project_directories") == [project_path]
 
-    # add yet another project
+    # add yet another project and see that it is added first in the list
     new_project_path = Path("/new/project")
     add_to_user_recent_projects(new_project_path, user_dir)
     assert user_dir.get_config_value("recent_project_directories") == [
-        project_path,
         new_project_path,
+        project_path,
     ]
 
 
@@ -58,9 +58,9 @@ def test_add_to_user_recent_projects_removes_oldest_when_full(
     assert len(project_paths) == max_number_of_recent_projects
 
     # add a new project and check that the length
-    # is still 5 and the oldest is removed
+    # is still 5 and the oldest (last) is removed
     new_path = Path("/project/new")
-    expected_recent_projects = project_paths[1:] + [new_path]
+    expected_recent_projects = [new_path] + project_paths[:-1]
     add_to_user_recent_projects(new_path, user_dir)
     recent_projects = user_dir.get_config_value("recent_project_directories")
     assert recent_projects == expected_recent_projects


### PR DESCRIPTION
Resolves #115 

PR to reverse the order of the `recent_project_directories` to get the most recent project first in the list.

## Checklist

- [x] Tests modified (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
