### PR TITLE
BUG: Fix missing f-string

### DIFF
--- a/src/fmu_settings_api/v1/routes/smda/main.py
+++ b/src/fmu_settings_api/v1/routes/smda/main.py
@@ -270,7 +270,7 @@ async def post_masterdata(
     except KeyError as e:
         raise HTTPException(
             status_code=500,
-            detail="Malformed response from SMDA: {e}",
+            detail=f"Malformed response from SMDA: {e}",
             headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
         ) from e
     except Exception as e:


### PR DESCRIPTION
Resolves #106 

Added missing f-string to the exception message.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
