### PR TITLE
STY: Ensure 'noqa' specifies ruff code only

### DIFF
--- a/src/fmu_settings_api/__main__.py
+++ b/src/fmu_settings_api/__main__.py
@@ -43,7 +43,7 @@ async def health_check() -> Ok:
     return Ok()
 
 
-def run_server(  # noqa PLR0913
+def run_server(  # noqa: PLR0913
     *,
     host: str = "127.0.0.1",
     port: int = 8001,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from fmu_settings_api.session import SessionManager, add_fmu_project_to_session
 @pytest.fixture
 def mock_token() -> str:
     """Sets a token."""
-    from fmu_settings_api.config import settings  # noqa PLC0415
+    from fmu_settings_api.config import settings  # noqa: PLC0415
 
     token = "safe" * 16
     settings.TOKEN = token

--- a/tests/test_main_config.py
+++ b/tests/test_main_config.py
@@ -18,7 +18,7 @@ def test_generator_auth_token() -> None:
     """Tests that the token is of the correct size."""
     token = generate_auth_token()
     assert isinstance(token, str)
-    assert len(token) == 64  # noqa PLR2004
+    assert len(token) == 64  # noqa: PLR2004
     assert token != generate_auth_token()
 
 

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -242,7 +242,7 @@ async def test_get_project_updates_session(
     session_id = client_with_session.cookies.get(settings.SESSION_COOKIE_KEY, None)
     assert session_id is not None
 
-    from fmu_settings_api.session import session_manager  # noqa PLC0415
+    from fmu_settings_api.session import session_manager  # noqa: PLC0415
 
     session = await session_manager.get_session(session_id)
     assert session is not None
@@ -273,7 +273,7 @@ async def test_get_project_already_in_session(
     )
     assert session_id is not None
 
-    from fmu_settings_api.session import session_manager  # noqa PLC0415
+    from fmu_settings_api.session import session_manager  # noqa: PLC0415
 
     session = await session_manager.get_session(session_id)
     assert session is not None
@@ -456,7 +456,7 @@ async def test_post_fmu_directory_exists(
     session_id = client_with_session.cookies.get(settings.SESSION_COOKIE_KEY, None)
     assert session_id is not None
 
-    from fmu_settings_api.session import session_manager  # noqa PLC0415
+    from fmu_settings_api.session import session_manager  # noqa: PLC0415
 
     session = await session_manager.get_session(session_id)
     assert session is not None
@@ -488,7 +488,7 @@ async def test_post_fmu_directory_changes_session_instance(
     session_id = client_with_session.cookies.get(settings.SESSION_COOKIE_KEY, None)
     assert session_id is not None
 
-    from fmu_settings_api.session import session_manager  # noqa PLC0415
+    from fmu_settings_api.session import session_manager  # noqa: PLC0415
 
     session = await session_manager.get_session(session_id)
     assert session is not None
@@ -536,7 +536,7 @@ async def test_delete_project_session_returns_to_user_session(
     client_with_project_session: TestClient, session_tmp_path: Path
 ) -> None:
     """Tests that deleting a project session returns to a user session."""
-    from fmu_settings_api.session import session_manager  # noqa PLC0415
+    from fmu_settings_api.session import session_manager  # noqa: PLC0415
 
     session_id = client_with_project_session.cookies.get(
         settings.SESSION_COOKIE_KEY, None
@@ -705,7 +705,7 @@ async def test_post_init_updates_session_instance(
     session_id = client_with_session.cookies.get(settings.SESSION_COOKIE_KEY, None)
     assert session_id is not None
 
-    from fmu_settings_api.session import session_manager  # noqa PLC0415
+    from fmu_settings_api.session import session_manager  # noqa: PLC0415
 
     session = await session_manager.get_session(session_id)
     assert session is not None

--- a/tests/test_v1/test_session.py
+++ b/tests/test_v1/test_session.py
@@ -266,7 +266,7 @@ async def test_patch_access_token_to_user_fmu_session(
     session_id = client_with_session.cookies.get(settings.SESSION_COOKIE_KEY, None)
     assert session_id is not None
 
-    from fmu_settings_api.session import session_manager  # noqa PLC0415
+    from fmu_settings_api.session import session_manager  # noqa: PLC0415
 
     session = await session_manager.get_session(session_id)
     assert session is not None
@@ -297,7 +297,7 @@ async def test_patch_access_token_unknown_failure(
         session_id = client_with_session.cookies.get(settings.SESSION_COOKIE_KEY, None)
         assert session_id is not None
 
-        from fmu_settings_api.session import session_manager  # noqa PLC0415
+        from fmu_settings_api.session import session_manager  # noqa: PLC0415
 
         session = await session_manager.get_session(session_id)
         assert session is not None

--- a/tests/test_v1/test_smda.py
+++ b/tests/test_v1/test_smda.py
@@ -553,7 +553,7 @@ async def test_post_masterdata_multiple_fields(
         == HttpHeader.UPSTREAM_SOURCE_SMDA
     )
     response_data = response.json()
-    assert len(response_data["field"]) == 2  # noqa
+    assert len(response_data["field"]) == 2  # noqa: PLR2004
 
     mock_smda_instance.field.assert_called_once_with(
         ["DROGON", "VISERION"],


### PR DESCRIPTION
Resolves #127

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
