### PR TITLE
MAINT: Set default log level to critical

### DIFF
--- a/src/fmu_settings_api/__main__.py
+++ b/src/fmu_settings_api/__main__.py
@@ -51,10 +51,14 @@ def run_server(  # noqa: PLR0913
     frontend_port: int | None = None,
     token: str | None = None,
     reload: bool = False,
+    log_level: str = "critical",
 ) -> None:
     """Starts the API server."""
+    log_level = log_level.lower()
+
     if token:
         settings.TOKEN = token
+
     if frontend_host is not None and frontend_port is not None:
         settings.update_frontend_host(host=frontend_host, port=frontend_port)
 
@@ -83,9 +87,12 @@ def run_server(  # noqa: PLR0913
             reload=True,
             reload_dirs=["src"],
             reload_includes=[".env"],
+            log_level=log_level,
         )
     else:
-        server_config = uvicorn.Config(app=app, host=host, port=port)
+        server_config = uvicorn.Config(
+            app=app, host=host, port=port, log_level=log_level
+        )
         server = uvicorn.Server(server_config)
 
         try:


### PR DESCRIPTION
Resolves #151

This will hide all the 'INFO' log message emitted by the API. They will need to be enable by a CLI option that is forthcoming.

No tests since this is a clear-cut uvicorn option.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
