### PR TITLE
ENH: Handle more errors in write dependency

### DIFF
--- a/src/fmu_settings_api/deps.py
+++ b/src/fmu_settings_api/deps.py
@@ -112,6 +112,12 @@ async def get_project_session(
             status_code=401,
             detail="No FMU project directory open",
         )
+
+    if not session.project_fmu_directory.path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail="Project .fmu directory not found. It may have been deleted.",
+        )
     return session
 
 
@@ -201,6 +207,22 @@ async def check_write_permissions(project_session: ProjectSessionDep) -> None:
         HTTPException: If the project is read-only due to lock conflicts.
     """
     fmu_dir = project_session.project_fmu_directory
+    try:
+        if not fmu_dir._lock.is_locked(propagate_errors=True):
+            raise HTTPException(
+                status_code=423,
+                detail="Project is not locked. Acquire the lock before writing.",
+            )
+    except PermissionError as e:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Permission denied accessing .fmu at {fmu_dir.path}",
+        ) from e
+    except FileNotFoundError as e:
+        raise HTTPException(
+            status_code=423,
+            detail="Project lock file is missing. Project is treated as read-only.",
+        ) from e
     if not fmu_dir._lock.is_acquired():
         raise HTTPException(
             status_code=423,

--- a/src/fmu_settings_api/session.py
+++ b/src/fmu_settings_api/session.py
@@ -160,9 +160,7 @@ class SessionManager:
             try:
                 if lock.is_acquired():
                     lock.refresh()
-                    session.lock_errors.refresh = None
-                else:
-                    session.lock_errors.refresh = None
+                session.lock_errors.refresh = None
             except Exception as e:
                 session.lock_errors.refresh = str(e)
 

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -566,11 +566,6 @@ async def patch_masterdata(
     try:
         fmu_dir.set_config_value("masterdata.smda", smda_masterdata.model_dump())
         return Message(message=f"Saved SMDA masterdata to {fmu_dir.path}")
-    except PermissionError as e:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Permission denied updating .fmu at {fmu_dir.path}",
-        ) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
 
@@ -600,11 +595,6 @@ async def patch_model(project_session: ProjectSessionDep, model: Model) -> Messa
     try:
         fmu_dir.set_config_value("model", model.model_dump())
         return Message(message=f"Saved model data to {fmu_dir.path}")
-    except PermissionError as e:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Permission denied updating .fmu at {fmu_dir.path}",
-        ) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
 
@@ -634,11 +624,6 @@ async def patch_access(project_session: ProjectSessionDep, access: Access) -> Me
     try:
         fmu_dir.set_config_value("access", access.model_dump())
         return Message(message=f"Saved access data to {fmu_dir.path}")
-    except PermissionError as e:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Permission denied updating .fmu at {fmu_dir.path}",
-        ) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
 


### PR DESCRIPTION
Resolves #154 

Also catches a deleted .fmu/ in a `get_session` dependency. Requires the latest fmu-settings.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
