### PR TITLE
ENH: Allow sliding session expiration

### DIFF
--- a/src/fmu_settings_api/session.py
+++ b/src/fmu_settings_api/session.py
@@ -132,7 +132,9 @@ class SessionManager:
 
         return session_id
 
-    async def get_session(self: Self, session_id: str) -> Session | ProjectSession:
+    async def get_session(
+        self: Self, session_id: str, extend_expiration: bool = True
+    ) -> Session | ProjectSession:
         """Get the session data for a session id.
 
         Params:
@@ -154,6 +156,10 @@ class SessionManager:
             raise SessionNotFoundError("Invalid or expired session")
 
         session.last_accessed = now
+
+        if extend_expiration:
+            expiration_duration = timedelta(seconds=settings.SESSION_EXPIRE_SECONDS)
+            session.expires_at = now + expiration_duration
 
         if isinstance(session, ProjectSession):
             lock = session.project_fmu_directory._lock

--- a/src/fmu_settings_api/v1/main.py
+++ b/src/fmu_settings_api/v1/main.py
@@ -10,7 +10,7 @@ from .routes import project, session, user
 from .routes.smda import main as smda
 
 api_v1_router = APIRouter()
-api_v1_router.include_router(project.router, dependencies=[Depends(get_session)])
+api_v1_router.include_router(project.router)
 api_v1_router.include_router(user.router, dependencies=[Depends(get_session)])
 api_v1_router.include_router(session.router)
 api_v1_router.include_router(smda.router, dependencies=[Depends(get_smda_session)])

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -20,6 +20,7 @@ from pydantic import ValidationError
 
 from fmu_settings_api.deps import (
     ProjectSessionDep,
+    ProjectSessionNoExtendDep,
     SessionDep,
     WritePermissionDep,
 )
@@ -496,7 +497,7 @@ async def post_lock_acquire(project_session: ProjectSessionDep) -> Message:
         **ProjectResponses,
     },
 )
-async def get_lock_status(project_session: ProjectSessionDep) -> LockStatus:
+async def get_lock_status(project_session: ProjectSessionNoExtendDep) -> LockStatus:
     """Returns the lock status and lock file contents if available."""
     fmu_dir = project_session.project_fmu_directory
 


### PR DESCRIPTION
In most webapps it is an anti-pattern/security risk to have sliding session expirations based upon requests. In our use case, however, with shared same-site resources, it makes sense to. This ensures new sessions do not need to be recreated as long as the user is active and allows the GUI to think less about session expiration itself.

Resolves #156

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
