### PR TITLE
ENH: Delete stale lock when checking lock status

### DIFF
--- a/src/fmu_settings_api/services/session.py
+++ b/src/fmu_settings_api/services/session.py
@@ -109,6 +109,16 @@ class SessionService:
                 lock_file_exists = True
                 try:
                     lock_info = fmu_dir._lock.load(force=True, store_cache=False)
+                    if fmu_dir._lock._is_stale(lock_info):
+                        try:
+                            fmu_dir._lock.path.unlink()
+                            lock_file_exists = False
+                            lock_info = None
+                        except OSError as e:
+                            lock_file_read_error = (
+                                f"Failed to delete stale lock file: {str(e)}"
+                            )
+                            lock_info = None
                 except (OSError, PermissionError) as e:
                     lock_file_read_error = f"Failed to read lock file: {str(e)}"
                 except ValueError as e:


### PR DESCRIPTION
Resolves #205 

get_lock_status will delete stale lock now

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
