### PR TITLE
BUG: Update lock internal state after deleting the lock

### DIFF
--- a/src/fmu_settings_api/services/session.py
+++ b/src/fmu_settings_api/services/session.py
@@ -112,8 +112,7 @@ class SessionService:
                     if fmu_dir._lock._is_stale(lock_info):
                         try:
                             fmu_dir._lock.path.unlink()
-                            fmu_dir._lock._cache = None
-                            fmu_dir._lock._acquired_at = None
+                            fmu_dir._lock.release()
                             lock_file_exists = False
                             lock_info = None
                         except OSError as e:


### PR DESCRIPTION
Resolves #221 

Update lock internal state after deleting the lock if lock is stale in `/lock_status`

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
