### PR TITLE
BUG: Update `config.rms` should preserve other fields

### DIFF
--- a/src/fmu_settings_api/services/project.py
+++ b/src/fmu_settings_api/services/project.py
@@ -8,7 +8,6 @@ from fmu.settings._global_config import find_global_config
 from fmu.settings.models.project_config import (
     RmsCoordinateSystem,
     RmsHorizon,
-    RmsProject,
     RmsStratigraphicZone,
     RmsWell,
 )
@@ -102,7 +101,7 @@ class ProjectService:
         """Get the paths of RMS projects in this project directory."""
         return self._fmu_dir.find_rms_projects()
 
-    def update_rms(self, rms_project_path: Path) -> RmsProject:
+    def update_rms(self, rms_project_path: Path) -> str:
         """Save the RMS project path and version in the project FMU directory."""
         try:
             rms_version = RmsService.get_rms_version(rms_project_path)
@@ -111,12 +110,14 @@ class ProjectService:
                 f"RMS project path {rms_project_path} does not exist."
             ) from e
 
-        rms_project = RmsProject(
-            path=rms_project_path,
-            version=rms_version,
+        self._fmu_dir.update_config(
+            {
+                "rms.path": rms_project_path,
+                "rms.version": rms_version,
+            }
         )
-        self._fmu_dir.set_config_value("rms", rms_project.model_dump())
-        return rms_project
+
+        return rms_version
 
     def _ensure_rms_config_exists(self) -> None:
         """Ensure RMS config exists before updating individual fields."""

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -634,9 +634,9 @@ async def patch_rms(
 ) -> Message:
     """Saves the RMS project path and version in the project .fmu directory."""
     try:
-        rms_config = project_service.update_rms(rms_project_path.path)
+        rms_version = project_service.update_rms(rms_project_path.path)
         return Message(
-            message=f"Saved RMS project path with RMS version {rms_config.version} "
+            message=f"Saved RMS project path with RMS version {rms_version} "
             f"to {project_service.fmu_dir_path}"
         )
     except FileNotFoundError as e:

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -2445,7 +2445,7 @@ async def test_patch_rms_general_exception(
         ),
         patch.object(
             session.project_fmu_directory,
-            "set_config_value",
+            "update_config",
             side_effect=ValueError("Invalid RMS project path"),
         ),
     ):


### PR DESCRIPTION
Resolves #226 

- Changed `update_rms()` to use `update_config()` and return `str` as we only need the rms version

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
