### PR TITLE
BUG: Remove `structlog.format_exc_info` to fix warning

### DIFF
--- a/src/fmu_settings_api/logging.py
+++ b/src/fmu_settings_api/logging.py
@@ -85,7 +85,6 @@ def setup_logging(
 
     if settings.log_format == "json" or settings.is_production:
         processors += [
-            structlog.processors.format_exc_info,
             structlog.processors.JSONRenderer(),
         ]
     else:


### PR DESCRIPTION
Resolves #233

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
