### PR TITLE
ENH: Improve error handling for non-existing RMS Project

### DIFF
--- a/src/fmu_settings_api/v1/routes/rms.py
+++ b/src/fmu_settings_api/v1/routes/rms.py
@@ -10,6 +10,7 @@ from fmu.settings.models.project_config import (
     RmsStratigraphicZone,
     RmsWell,
 )
+from runrms.exceptions import RmsProjectNotFoundError
 
 from fmu_settings_api.deps import SessionServiceDep
 from fmu_settings_api.deps.rms import (
@@ -64,6 +65,13 @@ router = APIRouter(prefix="/rms", tags=["rms"])
                 {"detail": "RMS project path is not set in the project config file."},
             ],
         ),
+        **inline_add_response(
+            404,
+            "RMS project file does not exist at the configured path.",
+            [
+                {"detail": "RMS project not found at path: {rms_project_path}"},
+            ],
+        ),
     },
 )
 async def post_rms_project(
@@ -87,6 +95,11 @@ async def post_rms_project(
         )
     except SessionNotFoundError as e:
         raise HTTPException(status_code=401, detail=str(e)) from e
+    except RmsProjectNotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"RMS project not found at path: {rms_project_path}",
+        ) from e
 
 
 @router.delete(


### PR DESCRIPTION
Resolves #230

Show a proper error message from the API for non-existing RMS Project instead of 500 Internal Server Error

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
