### PR TITLE
MAINT: Remove `is_read_only` property

### DIFF
--- a/src/fmu_settings_api/models/project.py
+++ b/src/fmu_settings_api/models/project.py
@@ -25,9 +25,6 @@ class FMUProject(FMUDirPath):
     config: ProjectConfig
     """The configuration of an FMU project's .fmu directory."""
 
-    is_read_only: bool = Field(default=False)
-    """Whether the project is in read-only mode due to lock conflicts."""
-
 
 class GlobalConfigPath(BaseResponseModel):
     """A relative path to a global config file, relative to the project root."""

--- a/src/fmu_settings_api/services/project.py
+++ b/src/fmu_settings_api/services/project.py
@@ -27,13 +27,10 @@ class ProjectService:
 
     def get_project_data(self) -> FMUProject:
         """Get the paths and configuration of the project FMU directory."""
-        is_read_only = not self._fmu_dir._lock.is_acquired()
-
         return FMUProject(
             path=self._fmu_dir.base_path,
             project_dir_name=self._fmu_dir.base_path.name,
             config=self._fmu_dir.config.load(),
-            is_read_only=is_read_only,
         )
 
     @property

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -209,7 +209,6 @@ async def test_get_project_directory_exists(
     assert fmu_project.path == session_tmp_path
     assert fmu_project.project_dir_name == session_tmp_path.name
     assert existing_fmu_dir.config.load() == fmu_project.config
-    assert fmu_project.is_read_only is False
 
 
 async def test_get_project_writes_to_user_recent_projects(


### PR DESCRIPTION
Resolves #244 

Remove `is_read_only` property because the GUI doesn't use it anymore

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
