### PR TITLE
BUG: Prevent double shutdown of `runrms` executor

### DIFF
--- a/src/fmu_settings_api/services/rms.py
+++ b/src/fmu_settings_api/services/rms.py
@@ -9,9 +9,10 @@ from fmu.settings.models.project_config import (
     RmsWell,
 )
 from packaging.version import Version
-from runrms import get_rmsapi
+from runrms import get_executor
 from runrms.api import RmsApiProxy
 from runrms.config._rms_config import RmsConfig
+from runrms.executor import ApiExecutor
 
 MIN_RMS_API_VERSION_FOR_STRAT_COLUMNS = Version("1.12")
 
@@ -34,7 +35,7 @@ class RmsService:
 
     def open_rms_project(
         self, rms_project_path: Path, rms_version: str
-    ) -> tuple[RmsApiProxy, RmsApiProxy]:
+    ) -> tuple[ApiExecutor, RmsApiProxy]:
         """Open an RMS project at the specified Path with the specified RMS version.
 
         Args:
@@ -42,10 +43,12 @@ class RmsService:
             rms_version: RMS Version to use (e.g. "14.2.2" or "15.0.1.0")
 
         Returns:
-            RmsApiProxy: The opened RMS project proxy
+            tuple[ApiExecutor, RmsApiProxy]: The executor and the opened RMS project
+            proxy
         """
-        rms_proxy = get_rmsapi(version=rms_version)
-        return rms_proxy, rms_proxy.Project.open(str(rms_project_path), readonly=True)
+        executor = get_executor(version=rms_version)
+        rms_proxy = executor.run()
+        return executor, rms_proxy.Project.open(str(rms_project_path), readonly=True)
 
     def get_zones(self, rms_project: RmsApiProxy) -> list[RmsStratigraphicZone]:
         """Retrieve the zones from the RMS project.

--- a/src/fmu_settings_api/services/session.py
+++ b/src/fmu_settings_api/services/session.py
@@ -10,6 +10,7 @@ from fmu.settings import (
 )
 from fmu.settings._init import init_fmu_directory
 from runrms.api import RmsApiProxy
+from runrms.executor import ApiExecutor
 
 from fmu_settings_api.models import AccessToken, SessionResponse
 from fmu_settings_api.models.project import LockStatus
@@ -145,9 +146,11 @@ class SessionService:
             last_lock_refresh_error=project_session.lock_errors.refresh,
         )
 
-    async def add_rms_session(self, root: RmsApiProxy, project: RmsApiProxy) -> None:
+    async def add_rms_session(
+        self, executor: ApiExecutor, project: RmsApiProxy
+    ) -> None:
         """Add an RMS session to the project session."""
-        await add_rms_project_to_session(self._session.id, root, project)
+        await add_rms_project_to_session(self._session.id, executor, project)
 
     async def remove_rms_session(self) -> None:
         """Removes an RMS session from the project session."""

--- a/src/fmu_settings_api/v1/routes/rms.py
+++ b/src/fmu_settings_api/v1/routes/rms.py
@@ -127,8 +127,8 @@ async def post_rms_project(
             if rms_version is not None
             else rms_service.get_rms_version(rms_project_path)
         )
-        root_proxy, project = rms_service.open_rms_project(rms_project_path, version)
-        await session_service.add_rms_session(root_proxy, project)
+        executor, project = rms_service.open_rms_project(rms_project_path, version)
+        await session_service.add_rms_session(executor, project)
         return Message(
             message=f"RMS project opened successfully with RMS version {version}."
         )

--- a/src/fmu_settings_api/v1/routes/session.py
+++ b/src/fmu_settings_api/v1/routes/session.py
@@ -96,7 +96,7 @@ async def post_session(
                 # Transfer existing RMS session to new session
                 await add_rms_project_to_session(
                     session_id,
-                    rms_session.root,
+                    rms_session.executor,
                     rms_session.project,
                 )
                 await remove_rms_project_from_session(

--- a/tests/test_services/test_rms_service.py
+++ b/tests/test_services/test_rms_service.py
@@ -53,16 +53,22 @@ def test_open_rms_project_success(rms_service: RmsService) -> None:
 
     mock_rmsapi = MagicMock()
     mock_rmsapi.Project.open.return_value = "opened_project"
+    mock_executor = MagicMock()
+    mock_executor.run.return_value = mock_rmsapi
 
-    with patch("fmu_settings_api.services.rms.get_rmsapi", return_value=mock_rmsapi):
-        root, opened_project = rms_service.open_rms_project(
+    with patch(
+        "fmu_settings_api.services.rms.get_executor",
+        return_value=mock_executor,
+    ):
+        executor, opened_project = rms_service.open_rms_project(
             rms_project_path, rms_version
         )
 
+        mock_executor.run.assert_called_once()
         mock_rmsapi.Project.open.assert_called_once_with(
             str(rms_project_path), readonly=True
         )
-        assert root == mock_rmsapi
+        assert executor == mock_executor
         assert opened_project == "opened_project"
 
 

--- a/tests/test_v1/test_rms_deps.py
+++ b/tests/test_v1/test_rms_deps.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi import HTTPException
 from runrms.api import RmsApiProxy
+from runrms.executor import ApiExecutor
 
 from fmu_settings_api.deps.rms import (
     get_opened_rms_project,
@@ -50,10 +51,10 @@ async def test_get_rms_project_path_not_configured() -> None:
 
 async def test_get_opened_rms_project_success() -> None:
     """Test getting opened RMS project when one is open."""
-    rms_root_mock = MagicMock(spec=RmsApiProxy)
+    rms_executor_mock = MagicMock(spec=ApiExecutor)
     rms_project_mock = MagicMock(spec=RmsApiProxy)
     project_session_mock = MagicMock()
-    project_session_mock.rms_session = RmsSession(rms_root_mock, rms_project_mock)
+    project_session_mock.rms_session = RmsSession(rms_executor_mock, rms_project_mock)
 
     result = await get_opened_rms_project(project_session_mock)
 

--- a/tests/test_v1/test_session.py
+++ b/tests/test_v1/test_session.py
@@ -509,13 +509,13 @@ async def test_new_session_preserves_rms_project_from_old_session(
     session_id = response.cookies.get(settings.SESSION_COOKIE_KEY)
     assert session_id is not None
 
-    rms_root = MagicMock(_shutdown=MagicMock())
+    rms_executor = MagicMock(shutdown=MagicMock())
     rms_project = MagicMock(close=MagicMock())
-    await add_rms_project_to_session(session_id, rms_root, rms_project)
+    await add_rms_project_to_session(session_id, rms_executor, rms_project)
 
     session = await session_manager.get_session(session_id)
     assert isinstance(session, ProjectSession)
-    assert session.rms_session == RmsSession(rms_root, rms_project)
+    assert session.rms_session == RmsSession(rms_executor, rms_project)
 
     different_path = tmp_path_mocked_home / "different_project"
     different_path.mkdir()
@@ -530,12 +530,12 @@ async def test_new_session_preserves_rms_project_from_old_session(
 
     new_session = await session_manager.get_session(new_session_id)
     assert isinstance(new_session, ProjectSession)
-    assert new_session.rms_session == RmsSession(rms_root, rms_project)
+    assert new_session.rms_session == RmsSession(rms_executor, rms_project)
 
     with pytest.raises(SessionNotFoundError):
         await session_manager.get_session(session_id)
 
-    rms_root._shutdown.assert_not_called()
+    rms_executor.shutdown.assert_not_called()
     rms_project.close.assert_not_called()
 
 


### PR DESCRIPTION
Resolves #268 

From issue description:
Problem: After opening/closing an RMS project via the API, pressing Ctrl+C hangs. With runrms <0.7.3 it prints “ZMQ socket not initialized”; with 0.7.3 it hangs instead (ZMQ recv timeout waiting for a reply from a worker that was already stopped).

Cause: The API called the root proxy’s private `_shutdown()` to stop the worker. `runrms` tracks executors globally and always calls `shutdown_all()` on exit. That triggers a second shutdown via `ApiExecutor.shutdown()`, which tries to send a shutdown request to a worker that is already dead.

- Pre 0.7.3: proxy `_shutdown()` also cleaned up sockets -> second shutdown fails with “ZMQ socket not initialized.”
- 0.7.3: proxy no longer cleans up sockets-> second shutdown blocks waiting for the ZMQ reply (recv timeout).

This problem appears because we store the root proxy but bypassed the executor lifecycle tracking by calling the private `_shutdown()` directly, making shutdowns non idempotent process.

Suggested fix:

- use `get_executor()` instead of `get_rmsapi()`
- store the executor in session instead of the root proxy
- call `executor.shutdown()` on cleanup instead of proxy `_shutdown()`

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
