### PR TITLE
ENH: Move mapping validation to fmu-settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version"]
 dependencies = [
     "fastapi",
     "fmu-datamodels",
-    "fmu-settings>=0.18.0",
+    "fmu-settings>=0.20.0",
     "httpx",
     "packaging",
     "pydantic",

--- a/src/fmu_settings_api/services/mappings.py
+++ b/src/fmu_settings_api/services/mappings.py
@@ -132,15 +132,11 @@ class MappingsService:
         Validates that:
         - All mappings match the specified mapping_type, source_system,
           and target_system
-        - No duplicate mappings (same source_id, source_uuid, target_id,
-          target_uuid, and relation_type)
-        - Mappings form valid groups (at most one primary per target, all
-          mappings share the same target context)
+        - New mappings form a valid MappingGroup
 
         Raises:
             ValueError: If validation fails or mapping type is unsupported
         """
-        seen: set[tuple[str, UUID | None, str, UUID | None, str]] = set()
         for mapping in new_mappings:
             if mapping.mapping_type != mapping_type:
                 raise ValueError(
@@ -158,23 +154,7 @@ class MappingsService:
                     f"found '{mapping.target_system}'"
                 )
 
-            key = (
-                mapping.source_id,
-                mapping.source_uuid,
-                mapping.target_id,
-                mapping.target_uuid,
-                mapping.relation_type.value,
-            )
-            if key in seen:
-                raise ValueError(
-                    f"Duplicate mapping found: source_id='{mapping.source_id}', "
-                    f"source_uuid='{mapping.source_uuid}', "
-                    f"target_id='{mapping.target_id}', "
-                    f"target_uuid='{mapping.target_uuid}', "
-                    f"relation_type='{mapping.relation_type.value}'"
-                )
-            seen.add(key)
-
+        # Validate that new_mappings form a valid MappingsGroup
         self.build_mapping_groups(new_mappings)
 
         if mapping_type == MappingType.stratigraphy:

--- a/tests/test_services/test_mappings_service.py
+++ b/tests/test_services/test_mappings_service.py
@@ -6,9 +6,12 @@ import pytest
 from fmu.datamodels.context.mappings import (
     DataSystem,
     MappingType,
+    RelationType,
+    StratigraphyIdentifierMapping,
     StratigraphyMappings,
 )
 from fmu.settings._fmu_dir import ProjectFMUDirectory
+from pydantic import ValidationError
 
 from fmu_settings_api.services.mappings import MappingsService
 
@@ -17,6 +20,21 @@ from fmu_settings_api.services.mappings import MappingsService
 def mappings_service(fmu_dir: ProjectFMUDirectory) -> MappingsService:
     """Returns a MappingsService instance."""
     return MappingsService(fmu_dir)
+
+
+def _make_stratigraphy_mapping(
+    source_id: str,
+    target_id: str,
+    relation_type: RelationType,
+) -> StratigraphyIdentifierMapping:
+    return StratigraphyIdentifierMapping(
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+        relation_type=relation_type,
+        source_id=source_id,
+        target_id=target_id,
+        target_uuid=None,
+    )
 
 
 def test_update_mappings_by_systems_mapping_type_mismatch(
@@ -40,6 +58,27 @@ def test_update_mappings_by_systems_mapping_type_mismatch(
         )
 
 
+def test_update_mappings_by_systems_source_system_mismatch(
+    mappings_service: MappingsService,
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Test that source system mismatch in body raises ValueError."""
+    fmu_dir.mappings.update_stratigraphy_mappings(StratigraphyMappings(root=[]))
+
+    wrong_target_mapping = Mock()
+    wrong_target_mapping.mapping_type = MappingType.stratigraphy
+    wrong_target_mapping.source_system = DataSystem.rms
+    wrong_target_mapping.target_system = DataSystem.fmu
+
+    with pytest.raises(ValueError, match="Source system mismatch"):
+        mappings_service.update_mappings_by_systems(
+            MappingType.stratigraphy,
+            DataSystem.fmu,
+            DataSystem.smda,
+            [wrong_target_mapping],
+        )
+
+
 def test_update_mappings_by_systems_target_system_mismatch(
     mappings_service: MappingsService,
     fmu_dir: ProjectFMUDirectory,
@@ -58,4 +97,66 @@ def test_update_mappings_by_systems_target_system_mismatch(
             DataSystem.rms,
             DataSystem.smda,
             [wrong_target_mapping],
+        )
+
+
+def test_update_mappings_by_systems_mapping_group_validation_error(
+    mappings_service: MappingsService,
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Test that invalid mapping combinations raises ValidationError."""
+    fmu_dir.mappings.update_stratigraphy_mappings(StratigraphyMappings(root=[]))
+
+    target_id = "Viking GP."
+    source_id = "Viking Gp."
+
+    # More than one primary mapping is an invalid combination
+    primary = _make_stratigraphy_mapping(source_id, target_id, RelationType.primary)
+    primary_two = _make_stratigraphy_mapping(
+        "VIKING GP", target_id, RelationType.primary
+    )
+    with pytest.raises(ValidationError, match="1 validation error for MappingGroup"):
+        mappings_service.update_mappings_by_systems(
+            MappingType.stratigraphy,
+            DataSystem.rms,
+            DataSystem.smda,
+            [primary, primary_two],
+        )
+
+    # More than one equivalent mapping is an invalid combination
+    equivalent = _make_stratigraphy_mapping(
+        source_id, source_id, RelationType.equivalent
+    )
+    equivalent_two = _make_stratigraphy_mapping(
+        source_id, source_id, RelationType.equivalent
+    )
+    with pytest.raises(ValidationError, match="1 validation error for MappingGroup"):
+        mappings_service.update_mappings_by_systems(
+            MappingType.stratigraphy,
+            DataSystem.rms,
+            DataSystem.smda,
+            [equivalent, equivalent_two],
+        )
+
+    # Alias mapping without primary mapping is an invalid combination
+    alias = _make_stratigraphy_mapping("Viking gp", target_id, RelationType.alias)
+    with pytest.raises(ValidationError, match="1 validation error for MappingGroup"):
+        mappings_service.update_mappings_by_systems(
+            MappingType.stratigraphy,
+            DataSystem.rms,
+            DataSystem.smda,
+            [alias],
+        )
+
+    # Duplicate mappings is an invalid combination
+    primary = _make_stratigraphy_mapping(source_id, target_id, RelationType.primary)
+    alias_to_duplicate = _make_stratigraphy_mapping(
+        "Viking gp", target_id, RelationType.alias
+    )
+    with pytest.raises(ValidationError, match="1 validation error for MappingGroup"):
+        mappings_service.update_mappings_by_systems(
+            MappingType.stratigraphy,
+            DataSystem.rms,
+            DataSystem.smda,
+            [primary, alias, alias_to_duplicate],
         )

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -3163,40 +3163,6 @@ async def test_put_mappings_stratigraphy_file_not_found(
     assert response.json() == {"detail": "Mappings file not found"}
 
 
-async def test_put_mappings_stratigraphy_duplicate_mappings(
-    client_with_project_session: TestClient,
-    session_manager: SessionManager,
-) -> None:
-    """Test 400 returns when request contains duplicate mappings."""
-    session_id = client_with_project_session.cookies.get(
-        settings.SESSION_COOKIE_KEY, None
-    )
-    assert session_id is not None
-    session = await session_manager.get_session(session_id)
-    assert isinstance(session, ProjectSession)
-
-    fmu_dir = session.project_fmu_directory
-    fmu_dir.mappings.update_stratigraphy_mappings(StratigraphyMappings(root=[]))
-
-    duplicate_mapping = _make_stratigraphy_mapping(
-        "TopVolantis",
-        "VOLANTIS GP. Top",
-        RelationType.primary,
-        source_system=DataSystem.rms,
-        target_system=DataSystem.smda,
-    )
-    payload = [
-        duplicate_mapping.model_dump(mode="json"),
-        duplicate_mapping.model_dump(mode="json"),
-    ]
-
-    response = client_with_project_session.put(
-        f"{ROUTE}/mappings/stratigraphy/rms/smda", json=payload
-    )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "duplicate mapping" in response.json()["detail"].lower()
-
-
 async def test_put_mappings_stratigraphy_validation_error(
     client_with_project_session: TestClient,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -283,7 +283,7 @@ wheels = [
 
 [[package]]
 name = "fmu-settings"
-version = "0.19.0"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -293,9 +293,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/92/f918add972c11ccd0bc3ad00e4977c18d23f4f80d99547a94c367b1ada61/fmu_settings-0.19.0.tar.gz", hash = "sha256:54e7fcf5c2852f416a4653f27837581874a5d3c2d1f5ffd9e120e1daaa20aa21", size = 131912, upload-time = "2026-01-28T08:51:21.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/ff/2534bc70d768eca7a45e1c9c7ef425a09f76e575608367e264a22a44c6ee/fmu_settings-0.20.0.tar.gz", hash = "sha256:852727b8c640bef340b7f99f74e6ca57198b0183d282fc0c5ed1a82f26f75466", size = 133100, upload-time = "2026-02-05T08:28:12.989Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/b4/f93fbb39ec96d4462331cffa93de8a22c6da55c44011da30084bee97081d/fmu_settings-0.19.0-py3-none-any.whl", hash = "sha256:a28bf09a7ee40a104099e276b8ccc910a15da3f4deec048c3fd96749cb31ba20", size = 49349, upload-time = "2026-01-28T08:51:20.243Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/74/84d87d2179b1a299313f1c3f2029c5044fc4c6c81f51a1471eb0e4b8a284/fmu_settings-0.20.0-py3-none-any.whl", hash = "sha256:529a21572985e7efe482794feaf5347f79bace3e571913e71cfeb6821b26529a", size = 49758, upload-time = "2026-02-05T08:28:11.881Z" },
 ]
 
 [[package]]
@@ -335,7 +335,7 @@ dev = [
 requires-dist = [
     { name = "fastapi" },
     { name = "fmu-datamodels" },
-    { name = "fmu-settings", specifier = ">=0.18.0" },
+    { name = "fmu-settings", specifier = ">=0.20.0" },
     { name = "fmu-settings-cli", marker = "extra == 'dev'" },
     { name = "httpx" },
     { name = "mypy", marker = "extra == 'dev'" },


### PR DESCRIPTION
Resolves last part of https://github.com/equinor/fmu-settings/issues/165

Remove redundant mapping validation from `MappingService` that was moved to `fmu-settings`.

Bumped dependency `fmu-settings` version to `0.20.0` to get the new `MappingGroup` validation rules. 

Updated tests accordingly.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
