### PR TITLE
ENH: Add release lock endpoint

### DIFF
--- a/src/fmu_settings_api/services/session.py
+++ b/src/fmu_settings_api/services/session.py
@@ -21,6 +21,7 @@ from fmu_settings_api.session import (
     add_access_token_to_session as add_token_to_session_manager,
     add_fmu_project_to_session,
     add_rms_project_to_session,
+    release_project_lock,
     remove_fmu_project_from_session,
     remove_rms_project_from_session,
     try_acquire_project_lock,
@@ -91,6 +92,13 @@ class SessionService:
         lock = updated_session.project_fmu_directory._lock
 
         return lock.is_acquired()
+
+    async def release_project_lock(self) -> bool:
+        """Attempt to release the project lock for this session."""
+        updated_session = await release_project_lock(self._session.id)
+        lock = updated_session.project_fmu_directory._lock
+
+        return not lock.is_acquired()
 
     def get_lock_status(self) -> LockStatus:
         """Get the lock status including session-specific error information."""


### PR DESCRIPTION
Resolves #301 

GUI needs a way to release lock

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
