### PR TITLE
ENH: Add endpoint to get sumo assets

### DIFF
--- a/src/fmu_settings_api/interfaces/__init__.py
+++ b/src/fmu_settings_api/interfaces/__init__.py
@@ -1,7 +1,9 @@
 """Interfaces for interacting with outside services."""
 
 from .smda_api import SmdaAPI
+from .sumo_api import SumoApi
 
 __all__ = [
     "SmdaAPI",
+    "SumoApi",
 ]

--- a/src/fmu_settings_api/interfaces/sumo_api.py
+++ b/src/fmu_settings_api/interfaces/sumo_api.py
@@ -1,0 +1,40 @@
+"""Interface for querying Sumo's API."""
+
+import json
+from pathlib import Path
+from typing import Final, Self
+
+from pydantic import TypeAdapter
+
+from fmu_settings_api.models.project import SumoAsset
+
+
+class SumoApi:
+    """Class for interacting with Sumos API."""
+
+    def __init__(self: Self) -> None:
+        """Initializes the SumoApi interface."""
+        self._asset_filepath: Final[Path] = Path(__file__).parent / Path(
+            "sumo_assets.json"
+        )
+
+    def get_assets(self: Self) -> list[SumoAsset]:
+        """Gets the Sumo assets."""
+        return self._read_assets_from_file(self._asset_filepath)
+
+    @staticmethod
+    def _read_assets_from_file(filepath: Path) -> list[SumoAsset]:
+        """Reads the valid Sumo assets from file.
+
+        The file serves as a temporary alternative to the Sumo endpoint, until
+        we set up the intergration towards Sumo. The file is maintained and kept in
+        sync with the assets that are onboarded to Sumo.
+
+        Raises:
+            ValidationError: If Sumo assets read from file are not valid.
+            JSONDecodeError: If json file to read is not a valid json.
+            FileNotFoundError: If the file to read is not found.
+        """
+        with open(filepath, encoding="utf-8") as stream:
+            sumo_assets = json.load(stream)
+        return TypeAdapter(list[SumoAsset]).validate_python(sumo_assets)

--- a/src/fmu_settings_api/interfaces/sumo_assets.json
+++ b/src/fmu_settings_api/interfaces/sumo_assets.json
@@ -1,0 +1,117 @@
+[
+    {
+        "name": "Drogon",
+        "code": "001",
+        "roleprefix": "DROGON"
+    },
+    {
+        "name": "Johan Sverdrup",
+        "code": "002",
+        "roleprefix": "JOHAN-SVERDRUP"
+    },
+    {
+        "name": "Breidablikk",
+        "code": "003",
+        "roleprefix": "BREIDABLIKK"
+    },
+    {
+        "name": "Smørbukk",
+        "code": "004",
+        "roleprefix": "SMORBUKK"
+    },
+    {
+        "name": "Heidrun",
+        "code": "005",
+        "roleprefix": "HEIDRUN"
+    },
+    {
+        "name": "Johan Castberg",
+        "code": "006",
+        "roleprefix": "JOHAN-CASTBERG"
+    },
+    {
+        "name": "Snorre",
+        "code": "007",
+        "roleprefix": "SNORRE"
+    },
+    {
+        "name": "Grosbeak",
+        "code": "008",
+        "roleprefix": "GROSBEAK"
+    },
+    {
+        "name": "Troll",
+        "code": "009",
+        "roleprefix": "TROLL"
+    },
+    {
+        "name": "Rosebank",
+        "code": "010",
+        "roleprefix": "ROSEBANK"
+    },
+    {
+        "name": "Wisting",
+        "code": "011",
+        "roleprefix": "WISTING"
+    },
+    {
+        "name": "Oseberg",
+        "code": "012",
+        "roleprefix": "OSEBERG"
+    },
+    {
+        "name": "DIG_CCS_SUB",
+        "code": "013",
+        "roleprefix": "DIG_CCS_SUB"
+    },
+    {
+        "name": "Tordis",
+        "code": "014",
+        "roleprefix": "TORDIS"
+    },
+    {
+        "name": "Bauge",
+        "code": "015",
+        "roleprefix": "BAUGE"
+    },
+    {
+        "name": "Grane",
+        "code": "016",
+        "roleprefix": "GRANE"
+    },
+    {
+        "name": "Martin Linge",
+        "code": "017",
+        "roleprefix": "MARTIN-LINGE"
+    },
+    {
+        "name": "Njord",
+        "code": "018",
+        "roleprefix": "NJORD"
+    },
+    {
+        "name": "Raia",
+        "code": "019",
+        "roleprefix": "RAIA"
+    },
+    {
+        "name": "Aasta Hansteen",
+        "code": "020",
+        "roleprefix": "AASTA-HANSTEEN"
+    },
+    {
+        "name": "Tyrihans",
+        "code": "021",
+        "roleprefix": "TYRIHANS"
+    },
+    {
+        "name": "Fram",
+        "code": "022",
+        "roleprefix": "FRAM"
+    },
+    {
+        "name": "Smørbukk Midt",
+        "code": "023",
+        "roleprefix": "SMORBUKK-MIDT"
+    }
+]

--- a/src/fmu_settings_api/models/project.py
+++ b/src/fmu_settings_api/models/project.py
@@ -66,3 +66,16 @@ class LockStatus(BaseResponseModel):
 
     last_lock_refresh_error: str | None = Field(default=None)
     """Error message from the last attempt to refresh the lock."""
+
+
+class SumoAsset(BaseResponseModel):
+    """A valid asset in Sumo."""
+
+    name: str
+    """Name of the asset in Sumo."""
+
+    code: str
+    """Code of the asset in Sumo."""
+
+    roleprefix: str
+    """Roleprefix of the asset in Sumo."""

--- a/src/fmu_settings_api/services/project.py
+++ b/src/fmu_settings_api/services/project.py
@@ -13,8 +13,9 @@ from fmu.settings.models.project_config import (
     RmsWell,
 )
 
+from fmu_settings_api.interfaces import SumoApi
 from fmu_settings_api.models import FMUProject
-from fmu_settings_api.models.project import CacheRetention, GlobalConfigPath
+from fmu_settings_api.models.project import CacheRetention, GlobalConfigPath, SumoAsset
 
 from .rms import RmsService
 
@@ -156,3 +157,7 @@ class ProjectService:
         self._fmu_dir.set_config_value(
             "rms.wells", [well.model_dump() for well in wells]
         )
+
+    def get_sumo_assets(self) -> list[SumoAsset]:
+        """Get the Sumo assets."""
+        return SumoApi().get_assets()

--- a/tests/test_interfaces/test_sumo_api.py
+++ b/tests/test_interfaces/test_sumo_api.py
@@ -1,0 +1,126 @@
+"""Test Sumo Api interface."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from fmu_settings_api.interfaces.sumo_api import SumoApi
+from fmu_settings_api.models.project import SumoAsset
+
+
+@pytest.fixture
+def sumo_assets() -> list[SumoAsset]:
+    """List of Sumo assets."""
+    return [
+        SumoAsset(name="TestAsset", code="001", roleprefix="ASSET1"),
+        SumoAsset(name="TestAsset2", code="002", roleprefix="ASSET2"),
+        SumoAsset(name="TestAsset3", code="003", roleprefix="ASSET3"),
+    ]
+
+
+def test_sumo_api_get_assets(
+    sumo_assets: list[SumoAsset],
+) -> None:
+    """Tests that sumo assets are returned as expected."""
+    api = SumoApi()
+
+    with patch.object(
+        api,
+        "_read_assets_from_file",
+        return_value=sumo_assets,
+    ) as mocked_method:
+        assets = api.get_assets()
+
+        mocked_method.assert_called_once_with(api._asset_filepath)
+        assert len(assets) == len(sumo_assets)
+        assert assets == sumo_assets
+
+
+def test_sumo_api_read_assets_from_file(
+    sumo_assets: list[SumoAsset],
+    tmp_path: Path,
+) -> None:
+    """Tests that sumo assets are read from file at the expected path."""
+    file_path = tmp_path / "sumo_assets.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump([asset.model_dump() for asset in sumo_assets], f, indent=2)
+
+    api = SumoApi()
+    assets = api._read_assets_from_file(file_path)
+
+    assert len(assets) == len(sumo_assets)
+    assert assets == sumo_assets
+
+
+def test_sumo_api_read_assets_from_file_raises_validation_error(
+    tmp_path: Path,
+) -> None:
+    """Tests that invalid Sumo assets in file raises ValidationError."""
+    file_path = tmp_path / "sumo_assets.json"
+    invalid_model = {"name": "invalid_model"}
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump([invalid_model], f, indent=2)
+
+    api = SumoApi()
+    with pytest.raises(ValidationError):
+        api._read_assets_from_file(file_path)
+
+
+def test_sumo_api_read_assets_from_file_raises_json_error(tmp_path: Path) -> None:
+    """Tests that non-json file content raises JSONDecodeError."""
+    file_path = tmp_path / "sumo_assets.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write("Some string that is not a valid json")
+
+    api = SumoApi()
+    with pytest.raises(json.JSONDecodeError):
+        api._read_assets_from_file(file_path)
+
+
+def test_sumo_api_read_assets_from_file_raises_file_not_found(tmp_path: Path) -> None:
+    """Tests that FileNotFoundError is raised when file to read does not exist."""
+    file_path = tmp_path / "sumo_assets.json"
+    api = SumoApi()
+    with pytest.raises(FileNotFoundError):
+        api._read_assets_from_file(file_path)
+
+
+def test_sumo_assets_json_file() -> None:
+    """Tests that the sumo_assets.json file is according to rules.
+
+    This test is here to catch if the sumo_assets.json
+    file is updated wrongly and not according to the rules.
+    """
+    api = SumoApi()
+    assets = api.get_assets()
+
+    # Check uniquness of name among Sumo assets
+    names_list = [asset.name for asset in assets]
+    assert len(names_list) == len(set(names_list))
+
+    # Check uniquness of code among Sumo assets
+    codes_list = [asset.code for asset in assets]
+    assert len(codes_list) == len(set(codes_list))
+
+    # Check uniquness of roleprefix among Sumo assets
+    roleprefix_list = [asset.roleprefix for asset in assets]
+    assert len(roleprefix_list) == len(set(roleprefix_list))
+
+    # Check that code can be parsed as int and is always increased by one
+    last_code = 0
+    for asset in assets:
+        code_as_int = int(asset.code)
+        assert code_as_int == last_code + 1
+        last_code = code_as_int
+
+    # Check that roleprefix relates to name
+    for asset in assets:
+        roleprefix = asset.roleprefix
+        roleprefix_parts = roleprefix.split("-")
+        asset_name = (
+            asset.name.casefold().replace("æ", "e").replace("ø", "o").replace("å", "a")
+        )
+        assert all(part.casefold() in asset_name for part in roleprefix_parts)

--- a/tests/test_services/test_project_service.py
+++ b/tests/test_services/test_project_service.py
@@ -12,7 +12,7 @@ from fmu.settings.models.project_config import (
     RmsWell,
 )
 
-from fmu_settings_api.models.project import CacheRetention
+from fmu_settings_api.models.project import CacheRetention, SumoAsset
 from fmu_settings_api.services.project import ProjectService
 
 
@@ -301,3 +301,19 @@ def test_update_rms_fields_preserves_other_fields(fmu_dir: ProjectFMUDirectory) 
     assert saved_config.zones[0].name == "Zone A"
     assert str(saved_config.path) == "/some/path"
     assert saved_config.version == "14.2.2"
+
+
+def test_project_service_get_sumo_assets(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Tests that sumo assets are returned as expected."""
+    asset = SumoAsset(name="TestAsset", code="001", roleprefix="TEST")
+    with patch(
+        "fmu_settings_api.interfaces.sumo_api.SumoApi.get_assets", return_value=[asset]
+    ) as class_init_mock:
+        service = ProjectService(fmu_dir)
+        sumo_assets = service.get_sumo_assets()
+        class_init_mock.assert_called_once()
+
+    assert len(sumo_assets) == 1
+    assert sumo_assets[0] == asset


### PR DESCRIPTION
Resolves #295 

Add new endpoint `/project/sumo_assets` to get all onboarded Sumo assets.

A new interface SumoApi has been added to handle requests towards Sumo: As a first iteration (before we add the Sumo intergration), the Sumo assets in the SumoApi interface `get_assets` method are fetched from a hardcoded file `sumo_assets.json`.

The plan is that Sudo team will update this hardcoded list as part of their onboarding of new assets in the same way they update this list https://github.com/equinor/sumo-infrastructure/blob/main/terraform/storage-accounts/assets.tf.

## Checklist

- [X] Tests added (if not, comment why)
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
