### PR TITLE
BUG: Fix project lock release semantics

### DIFF
--- a/src/fmu_settings_api/services/session.py
+++ b/src/fmu_settings_api/services/session.py
@@ -94,10 +94,13 @@ class SessionService:
 
     async def release_project_lock(self) -> bool:
         """Attempt to release the project lock for this session."""
+        project_session = cast("ProjectSession", self._session)
+        was_acquired = project_session.project_fmu_directory._lock.is_acquired()
+
         updated_session = await release_project_lock(self._session.id)
         lock = updated_session.project_fmu_directory._lock
 
-        return not lock.is_acquired()
+        return was_acquired and not lock.is_acquired()
 
     def get_lock_status(self) -> LockStatus:
         """Get the lock status including session-specific error information."""


### PR DESCRIPTION
Resolves #305 

If the lock was not acquired, the lock will not be released, but with current logic, `release_project_lock()` will return `True`, thus the route will return message `"Project lock released."`, which is misleading.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
