### PR TITLE
ENH: Add Bacalhau and Borg to Sumo assets

### DIFF
--- a/src/fmu_settings_api/interfaces/sumo_assets.json
+++ b/src/fmu_settings_api/interfaces/sumo_assets.json
@@ -113,5 +113,15 @@
         "name": "Smørbukk Midt",
         "code": "023",
         "roleprefix": "SMORBUKK-MIDT"
+    },
+    {
+        "name": "Bacalhau",
+        "code": "024",
+        "roleprefix": "BACALHAU"
+    },
+    {
+        "name": "Borg",
+        "code": "025",
+        "roleprefix": "BORG"
     }
 ]


### PR DESCRIPTION
Bacalhau and Borg have been onboarded and configured in Sumo.
This PR adds them to the list of assets recognized by fmu-settings.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
