### PR TITLE
ENH: Add restore from memory endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version"]
 dependencies = [
     "fastapi",
     "fmu-datamodels",
-    "fmu-settings>=0.21.0",
+    "fmu-settings>=0.22.0",
     "httpx",
     "packaging",
     "pydantic",

--- a/src/fmu_settings_api/services/session.py
+++ b/src/fmu_settings_api/services/session.py
@@ -50,6 +50,19 @@ class SessionService:
             last_accessed=self._session.last_accessed,
         )
 
+    def restore_fmu_directories(self) -> list[Path]:
+        """Restore missing .fmu resources for the current session."""
+        restored_paths = []
+
+        self._session.user_fmu_directory.restore()
+        restored_paths.append(self._session.user_fmu_directory.path)
+
+        if isinstance(self._session, ProjectSession):
+            self._session.project_fmu_directory.restore()
+            restored_paths.append(self._session.project_fmu_directory.path)
+
+        return restored_paths
+
     async def add_access_token(self, access_token: AccessToken) -> str:
         """Add a known access token to the session."""
         await add_token_to_session_manager(self._session.id, access_token)

--- a/uv.lock
+++ b/uv.lock
@@ -256,7 +256,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.131.0"
+version = "0.132.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -265,9 +265,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/32/158cbf685b7d5a26f87131069da286bf10fc9fbf7fc968d169d48a45d689/fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff", size = 369612, upload-time = "2026-02-22T16:38:11.252Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/1a/9c69b39a6c4d9b7f024e7761bb06bd7a4cc81f0e7bd717a5c1e66ccc9df4/fastapi-0.132.1.tar.gz", hash = "sha256:e5b224024e20ac2aa0141f1ca2c6014cf88b87dc447e31b4c8527c5cf403ce30", size = 373491, upload-time = "2026-02-24T09:34:07.741Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/94/b58ec24c321acc2ad1327f69b033cadc005e0f26df9a73828c9e9c7db7ce/fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a", size = 103854, upload-time = "2026-02-22T16:38:09.814Z" },
+    { url = "https://files.pythonhosted.org/packages/01/88/f872fd6220c5d3f0c5fd0b4746f84135e474e627329863dc1466559de5e2/fastapi-0.132.1-py3-none-any.whl", hash = "sha256:0f50df9aed7cfa379b0f4a7dbe798d3dfc2c6bfb05362fe5c7cc4795fa6d1b7a", size = 104789, upload-time = "2026-02-24T09:34:09.252Z" },
 ]
 
 [[package]]
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "fmu-settings"
-version = "0.21.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -306,9 +306,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/e5/8dc914ec7bf7d10bd5903901aa24270e6d3185224cb5c1beac8596ca74b9/fmu_settings-0.21.0.tar.gz", hash = "sha256:cb9e292dc507b0e29460ac38ecad535477f6b143ae9c57a495b1f998e1d1193e", size = 135473, upload-time = "2026-02-10T12:36:58.797Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/5f/b39b6e6d37704abcad2f91b3560039eec2bb95bd43ce66307b96ede58cee/fmu_settings-0.22.0.tar.gz", hash = "sha256:8b049a63a1516790e1a356324aad8df1d7da4dff37e425feab122d03bbfcbeeb", size = 135478, upload-time = "2026-02-24T09:14:54.752Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/b7/942d8fa54366e9c78aa1c7eb19151fafdb6dfdf3e3adce52f266bc976e7d/fmu_settings-0.21.0-py3-none-any.whl", hash = "sha256:2b648aa681aeb42496f1610e451ea3838b96f37e2718a44010f4f175d5ea6ce6", size = 51462, upload-time = "2026-02-10T12:36:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/fb/2cc3aa40bb50b93c77b4ffdb373c8d46e464ac948b9dd6a5102fad854b22/fmu_settings-0.22.0-py3-none-any.whl", hash = "sha256:e37e2bf4119348f1094767823c1e796fe22c64675471b7a536ee6904d3cc4db6", size = 51642, upload-time = "2026-02-24T09:14:53.441Z" },
 ]
 
 [[package]]
@@ -348,7 +348,7 @@ dev = [
 requires-dist = [
     { name = "fastapi" },
     { name = "fmu-datamodels" },
-    { name = "fmu-settings", specifier = ">=0.21.0" },
+    { name = "fmu-settings", specifier = ">=0.22.0" },
     { name = "fmu-settings-cli", marker = "extra == 'dev'" },
     { name = "httpx" },
     { name = "mypy", marker = "extra == 'dev'" },


### PR DESCRIPTION
Resolves #300

Added `POST session/restore` to restore both user and project .fmu and its resources from in-memory state.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
