### PR TITLE
MAINT: Remove .fmu path in success messages

### DIFF
--- a/src/fmu_settings_api/services/project.py
+++ b/src/fmu_settings_api/services/project.py
@@ -36,11 +36,6 @@ class ProjectService:
         )
 
     @property
-    def fmu_dir_path(self) -> Path:
-        """Returns the path to the .fmu directory."""
-        return self._fmu_dir.path
-
-    @property
     def config_path(self) -> Path:
         """Returns the path to the project config file."""
         return self._fmu_dir.config.path

--- a/src/fmu_settings_api/services/session.py
+++ b/src/fmu_settings_api/services/session.py
@@ -35,12 +35,6 @@ class SessionService:
         """Initialize the service with a session."""
         self._session = session
 
-    @property
-    def fmu_dir_path(self) -> Path:
-        """Returns the path to the attached project .fmu directory."""
-        project_session = cast("ProjectSession", self._session)
-        return project_session.project_fmu_directory.path
-
     def get_session_response(self) -> SessionResponse:
         """Get the session data in a serializable format."""
         return SessionResponse(
@@ -50,18 +44,11 @@ class SessionService:
             last_accessed=self._session.last_accessed,
         )
 
-    def restore_fmu_directories(self) -> list[Path]:
+    def restore_fmu_directories(self) -> None:
         """Restore missing .fmu resources for the current session."""
-        restored_paths = []
-
         self._session.user_fmu_directory.restore()
-        restored_paths.append(self._session.user_fmu_directory.path)
-
         if isinstance(self._session, ProjectSession):
             self._session.project_fmu_directory.restore()
-            restored_paths.append(self._session.project_fmu_directory.path)
-
-        return restored_paths
 
     async def add_access_token(self, access_token: AccessToken) -> str:
         """Add a known access token to the session."""

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -589,9 +589,7 @@ async def delete_project_session(
     """Deletes a project .fmu session if it exists."""
     try:
         await session_service.close_project()
-        return Message(
-            message=f"FMU directory {session_service.fmu_dir_path} closed successfully"
-        )
+        return Message(message="Project closed successfully")
     except SessionNotFoundError as e:
         raise HTTPException(status_code=401, detail=str(e)) from e
 
@@ -745,7 +743,7 @@ async def patch_masterdata(
 ) -> Message:
     """Saves SMDA masterdata to the project .fmu directory."""
     project_service.update_masterdata(smda_masterdata)
-    return Message(message=f"Saved SMDA masterdata to {project_service.fmu_dir_path}")
+    return Message(message="Saved SMDA masterdata")
 
 
 @router.patch(
@@ -769,7 +767,7 @@ async def patch_masterdata(
 async def patch_model(project_service: ProjectServiceDep, model: Model) -> Message:
     """Saves model data to the project .fmu directory."""
     project_service.update_model(model)
-    return Message(message=f"Saved model data to {project_service.fmu_dir_path}")
+    return Message(message="Saved model data")
 
 
 @router.patch(
@@ -793,7 +791,7 @@ async def patch_model(project_service: ProjectServiceDep, model: Model) -> Messa
 async def patch_access(project_service: ProjectServiceDep, access: Access) -> Message:
     """Saves access data to the project .fmu directory."""
     project_service.update_access(access)
-    return Message(message=f"Saved access data to {project_service.fmu_dir_path}")
+    return Message(message="Saved access data")
 
 
 @router.patch(
@@ -819,9 +817,7 @@ async def patch_cache_max_revisions(
 ) -> Message:
     """Saves cache max revisions to the project .fmu directory."""
     project_service.update_cache_max_revisions(cache_max_revisions)
-    return Message(
-        message=f"Saved cache max revisions to {project_service.fmu_dir_path}"
-    )
+    return Message(message="Saved cache max revisions")
 
 
 @router.get(
@@ -887,10 +883,7 @@ async def patch_rms(
     """Saves the RMS project path and version in the project .fmu directory."""
     try:
         rms_version = project_service.update_rms(rms_project_path.path)
-        return Message(
-            message=f"Saved RMS project path with RMS version {rms_version} "
-            f"to {project_service.fmu_dir_path}"
-        )
+        return Message(message=f"Saved RMS project path with RMS version {rms_version}")
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except RmsVersionError as e:
@@ -923,9 +916,7 @@ async def patch_rms_coordinate_system(
     """Saves the RMS coordinate system in the project .fmu directory."""
     try:
         project_service.update_rms_coordinate_system(coordinate_system)
-        return Message(
-            message=f"Saved RMS coordinate system to {project_service.fmu_dir_path}"
-        )
+        return Message(message="Saved RMS coordinate system")
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 
@@ -960,11 +951,7 @@ async def patch_rms_stratigraphic_framework(
         project_service.update_rms_stratigraphic_framework(
             stratigraphic_framework.zones, stratigraphic_framework.horizons
         )
-        return Message(
-            message=(
-                f"Saved RMS stratigraphic framework to {project_service.fmu_dir_path}"
-            )
-        )
+        return Message(message="Saved RMS stratigraphic framework")
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 
@@ -995,7 +982,7 @@ async def patch_rms_wells(
     """Saves the RMS wells in the project .fmu directory."""
     try:
         project_service.update_rms_wells(wells)
-        return Message(message=f"Saved RMS wells to {project_service.fmu_dir_path}")
+        return Message(message="Saved RMS wells")
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 
@@ -1253,7 +1240,7 @@ async def put_mappings(
         return Message(
             message=(
                 f"Saved {mapping_type.value} mappings from {source_system.value} to "
-                f"{target_system.value} to {mappings_service.fmu_dir_path}"
+                f"{target_system.value}"
             )
         )
     except FileNotFoundError as e:

--- a/src/fmu_settings_api/v1/routes/session.py
+++ b/src/fmu_settings_api/v1/routes/session.py
@@ -218,7 +218,7 @@ async def get_session(
 async def post_restore(session_service: SessionServiceDep) -> Message:
     """Attempt recovery of missing .fmu directories."""
     try:
-        restored_paths = session_service.restore_fmu_directories()
+        session_service.restore_fmu_directories()
     except FileExistsError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
     except PermissionError as e:
@@ -232,5 +232,4 @@ async def post_restore(session_service: SessionServiceDep) -> Message:
             detail="Permission denied recovering .fmu resources",
         ) from e
 
-    restored_paths_text = ", ".join(str(path) for path in restored_paths)
-    return Message(message=f"Restored .fmu resources at {restored_paths_text}")
+    return Message(message="Restored .fmu resources")

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -722,10 +722,7 @@ async def test_delete_project_session_returns_to_user_session(
 
     response = client_with_project_session.delete(ROUTE)
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert (
-        response.json()["message"]
-        == f"FMU directory {session.project_fmu_directory.path} closed successfully"
-    )
+    assert response.json()["message"] == "Project closed successfully"
     deleted_session_id = response.cookies.get(settings.SESSION_COOKIE_KEY, None)
     assert deleted_session_id is None
 
@@ -922,10 +919,7 @@ async def test_patch_masterdata_project(
         f"{ROUTE}/masterdata", json=smda_masterdata
     )
     assert response.status_code == status.HTTP_200_OK
-    assert (
-        response.json()["message"]
-        == f"Saved SMDA masterdata to {get_fmu_project.path / '.fmu'}"
-    )
+    assert response.json()["message"] == "Saved SMDA masterdata"
     # Refetch the project to see that masterdata is set
     get_response = client_with_project_session.get(ROUTE)
     get_fmu_project = FMUProject.model_validate(get_response.json())
@@ -1393,10 +1387,7 @@ async def test_patch_model_project(
     # Store model to project
     response = client_with_project_session.patch(f"{ROUTE}/model", json=model_data)
     assert response.status_code == status.HTTP_200_OK
-    assert (
-        response.json()["message"]
-        == f"Saved model data to {get_fmu_project.path / '.fmu'}"
-    )
+    assert response.json()["message"] == "Saved model data"
     # Refetch the project to see that model is set
     get_response = client_with_project_session.get(ROUTE)
     get_fmu_project = FMUProject.model_validate(get_response.json())
@@ -1490,10 +1481,7 @@ async def test_patch_access_project(
     # Store access to project
     response = client_with_project_session.patch(f"{ROUTE}/access", json=access_data)
     assert response.status_code == status.HTTP_200_OK
-    assert (
-        response.json()["message"]
-        == f"Saved access data to {get_fmu_project.path / '.fmu'}"
-    )
+    assert response.json()["message"] == "Saved access data"
     # Refetch the project to see that access is set
     get_response = client_with_project_session.get(ROUTE)
     get_fmu_project = FMUProject.model_validate(get_response.json())
@@ -1591,10 +1579,7 @@ async def test_patch_cache_max_revisions_project(
         json={"cache_max_revisions": updated_value},
     )
     assert response.status_code == status.HTTP_200_OK
-    assert (
-        response.json()["message"]
-        == f"Saved cache max revisions to {get_fmu_project.path / '.fmu'}"
-    )
+    assert response.json()["message"] == "Saved cache max revisions"
 
     get_response = client_with_project_session.get(ROUTE)
     get_fmu_project = FMUProject.model_validate(get_response.json())
@@ -2710,10 +2695,7 @@ async def test_patch_rms_success(
             json={"path": str(rms_path)},
         )
     assert response.status_code == status.HTTP_200_OK
-    expected_message = (
-        f"Saved RMS project path with RMS version 14.2.2 "
-        f"to {get_fmu_project.path / '.fmu'}"
-    )
+    expected_message = "Saved RMS project path with RMS version 14.2.2"
     assert response.json()["message"] == expected_message
 
     get_response = client_with_project_session.get(ROUTE)

--- a/tests/test_v1/test_session.py
+++ b/tests/test_v1/test_session.py
@@ -582,7 +582,7 @@ async def test_post_restore_session_restores_user_fmu_directory(
 
     response = client_with_session.post(f"{ROUTE}/restore")
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.json()["message"] == (f"Restored .fmu resources at {user_fmu_path}")
+    assert response.json()["message"] == "Restored .fmu resources"
     assert user_fmu_path.exists()
     assert session.user_fmu_directory.config.path.exists()
 
@@ -608,9 +608,7 @@ async def test_post_restore_session_restores_project_fmu_directory(
 
     response = client_with_project_session.post(f"{ROUTE}/restore")
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.json()["message"] == (
-        f"Restored .fmu resources at {user_fmu_path}, {project_fmu_path}"
-    )
+    assert response.json()["message"] == "Restored .fmu resources"
     assert project_fmu_path.exists()
     assert session.project_fmu_directory.config.path.exists()
 


### PR DESCRIPTION
Resolves #315 

Remove .fmu path in success messages

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
