### PR TITLE
ENH: Add Gudrun asset to sumo_assets.json

### DIFF
--- a/src/fmu_settings_api/interfaces/sumo_assets.json
+++ b/src/fmu_settings_api/interfaces/sumo_assets.json
@@ -128,5 +128,10 @@
         "name": "Linnorm",
         "code": "026",
         "roleprefix": "LINNORM"
+    },
+    {
+        "name": "Gudrun",
+        "code": "027",
+        "roleprefix": "GUDRUN"
     }
 ]


### PR DESCRIPTION
Gudrun has been onboarded and configured in Sumo.
This PR adds them to the list of assets recognized by fmu-settings.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
