### PR TITLE
BUG: Update to new SMDA endpoint

### DIFF
--- a/src/fmu_settings_api/interfaces/smda_api.py
+++ b/src/fmu_settings_api/interfaces/smda_api.py
@@ -12,7 +12,7 @@ class SmdaRoutes:
     """Contains routes used by routes in this API."""
 
     BASE_URL: Final[str] = "https://api.gateway.equinor.com/smda/v2.0"
-    HEALTH: Final[str] = "actuator/health"
+    HEALTH: Final[str] = "availability"
     FIELDS_SEARCH: Final[str] = "smda-api/fields/search"
     COUNTRIES_SEARCH: Final[str] = "smda-api/countries/search"
     DISCOVERIES_SEARCH: Final[str] = "smda-api/discoveries/search"

--- a/src/fmu_settings_api/services/smda.py
+++ b/src/fmu_settings_api/services/smda.py
@@ -188,10 +188,7 @@ class SmdaService:
         discovery_res = await self._smda.discovery(
             field_identifiers,
             columns=[
-                "field_identifier",
-                "identifier",
                 "short_identifier",
-                "projected_coordinate_system",
                 "uuid",
             ],
         )
@@ -213,7 +210,6 @@ class SmdaService:
         strat_column_res = await self._smda.strat_column_areas(
             field_identifiers,
             [
-                "identifier",
                 "uuid",
                 "strat_area_identifier",
                 "strat_column_identifier",

--- a/tests/test_services/test_smda_service.py
+++ b/tests/test_services/test_smda_service.py
@@ -112,10 +112,7 @@ async def test_get_discoveries(given: list[str], mock_val: list[DiscoveryItem]) 
     mock_smda.discovery.assert_called_with(
         given,
         columns=[
-            "field_identifier",
-            "identifier",
             "short_identifier",
-            "projected_coordinate_system",
             "uuid",
         ],
     )
@@ -186,7 +183,6 @@ async def test_get_strat_column_areas(
     mock_smda.strat_column_areas.assert_called_with(
         given,
         [
-            "identifier",
             "uuid",
             "strat_area_identifier",
             "strat_column_identifier",


### PR DESCRIPTION
Resolves #328 

Adapt to new SMDA health endpoint (ref [here](https://equinor.slack.com/archives/CC91UFAH3/p1774269718283149?thread_ts=1774269432.696809&cid=CC91UFAH3)) and their new response model. Have tried testing this from GUI and it works, but maybe you guys can check as well.

The new SMDA backend has:

- New health endpoint `/availability` instead of `actuator/health`
- No `projected_coordinate_system` attribute for the `_projection` in `/discoveries/search` endpoint
- No `identifier` attribute for the `_projection` in `/strat-column-areas/search` endpoint

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
