### PR TITLE
ENH: Separate user and project restore-from-memory flows

### DIFF
--- a/src/fmu_settings_api/deps/__init__.py
+++ b/src/fmu_settings_api/deps/__init__.py
@@ -4,7 +4,7 @@ from fmu_settings_api.interfaces.smda_api import SmdaAPI
 
 from .auth import AuthTokenDep
 from .permissions import RefreshLockDep, WritePermissionDep
-from .project import ProjectRestoreServiceDep, ProjectServiceDep
+from .project import ProjectServiceDep, ProjectServiceForRestoreDep
 from .resource import ResourceServiceDep
 from .session import (
     ProjectSessionDep,
@@ -39,6 +39,6 @@ __all__ = [
     "WritePermissionDep",
     "SmdaAPI",
     "ProjectServiceDep",
-    "ProjectRestoreServiceDep",
+    "ProjectServiceForRestoreDep",
     "ResourceServiceDep",
 ]

--- a/src/fmu_settings_api/deps/__init__.py
+++ b/src/fmu_settings_api/deps/__init__.py
@@ -4,7 +4,7 @@ from fmu_settings_api.interfaces.smda_api import SmdaAPI
 
 from .auth import AuthTokenDep
 from .permissions import RefreshLockDep, WritePermissionDep
-from .project import ProjectServiceDep
+from .project import ProjectRestoreServiceDep, ProjectServiceDep
 from .resource import ResourceServiceDep
 from .session import (
     ProjectSessionDep,
@@ -39,5 +39,6 @@ __all__ = [
     "WritePermissionDep",
     "SmdaAPI",
     "ProjectServiceDep",
+    "ProjectRestoreServiceDep",
     "ResourceServiceDep",
 ]

--- a/src/fmu_settings_api/deps/project.py
+++ b/src/fmu_settings_api/deps/project.py
@@ -20,7 +20,7 @@ async def get_project_service(
 ProjectServiceDep = Annotated[ProjectService, Depends(get_project_service)]
 
 
-async def get_restore_project_service(
+async def get_project_service_for_restore(
     session: SessionDep,
 ) -> ProjectService:
     """Returns a ProjectService for restore routes, even if .fmu is deleted."""
@@ -34,5 +34,5 @@ async def get_restore_project_service(
 
 
 ProjectServiceForRestoreDep = Annotated[
-    ProjectService, Depends(get_restore_project_service)
+    ProjectService, Depends(get_project_service_for_restore)
 ]

--- a/src/fmu_settings_api/deps/project.py
+++ b/src/fmu_settings_api/deps/project.py
@@ -33,6 +33,6 @@ async def get_restore_project_service(
     return ProjectService(session.project_fmu_directory)
 
 
-ProjectRestoreServiceDep = Annotated[
+ProjectServiceForRestoreDep = Annotated[
     ProjectService, Depends(get_restore_project_service)
 ]

--- a/src/fmu_settings_api/deps/project.py
+++ b/src/fmu_settings_api/deps/project.py
@@ -2,11 +2,12 @@
 
 from typing import Annotated
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 
 from fmu_settings_api.services.project import ProjectService
+from fmu_settings_api.session import ProjectSession
 
-from .session import ProjectSessionDep
+from .session import ProjectSessionDep, SessionDep
 
 
 async def get_project_service(
@@ -17,3 +18,21 @@ async def get_project_service(
 
 
 ProjectServiceDep = Annotated[ProjectService, Depends(get_project_service)]
+
+
+async def get_restore_project_service(
+    session: SessionDep,
+) -> ProjectService:
+    """Returns a ProjectService for restore routes, even if .fmu is deleted."""
+    if not isinstance(session, ProjectSession):
+        raise HTTPException(
+            status_code=401,
+            detail="No FMU project directory open",
+        )
+
+    return ProjectService(session.project_fmu_directory)
+
+
+ProjectRestoreServiceDep = Annotated[
+    ProjectService, Depends(get_restore_project_service)
+]

--- a/src/fmu_settings_api/models/__init__.py
+++ b/src/fmu_settings_api/models/__init__.py
@@ -1,6 +1,13 @@
 """Models used for messages and responses at API endpoints."""
 
-from .common import AccessToken, APIKey, BaseResponseModel, Message, Ok
+from .common import (
+    AccessToken,
+    APIKey,
+    BaseResponseModel,
+    Message,
+    Ok,
+    RestorableFilesResponse,
+)
 from .project import FMUDirPath, FMUProject
 from .session import SessionResponse
 
@@ -12,5 +19,6 @@ __all__ = [
     "FMUProject",
     "Message",
     "Ok",
+    "RestorableFilesResponse",
     "SessionResponse",
 ]

--- a/src/fmu_settings_api/models/common.py
+++ b/src/fmu_settings_api/models/common.py
@@ -1,5 +1,6 @@
 """Common response models from the API."""
 
+from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, SecretStr
@@ -21,6 +22,13 @@ class Message(BaseResponseModel):
     """A generic message to return to the GUI."""
 
     message: str
+
+
+class RestorableFilesResponse(BaseResponseModel):
+    """A list of missing .fmu files that can be restored or were restored."""
+
+    files: list[Path]
+    """Relative paths to the restorable or restored files."""
 
 
 class APIKey(BaseResponseModel):

--- a/src/fmu_settings_api/services/project.py
+++ b/src/fmu_settings_api/services/project.py
@@ -35,6 +35,19 @@ class ProjectService:
             config=self._fmu_dir.config.load(),
         )
 
+    def get_restorable_fmu_files(self) -> list[Path]:
+        """List missing project .fmu files that can currently be recovered."""
+        return self._fmu_dir.list_restorable_files()
+
+    def restore_fmu_files(self) -> list[Path]:
+        """Restore missing project .fmu resources."""
+        restorable_files = self.get_restorable_fmu_files()
+        if not restorable_files:
+            return []
+
+        self._fmu_dir.restore()
+        return restorable_files
+
     @property
     def config_path(self) -> Path:
         """Returns the path to the project config file."""

--- a/src/fmu_settings_api/services/session.py
+++ b/src/fmu_settings_api/services/session.py
@@ -46,11 +46,18 @@ class SessionService:
             last_accessed=self._session.last_accessed,
         )
 
-    def restore_fmu_directories(self) -> None:
-        """Restore missing .fmu resources for the current session."""
+    def get_restorable_fmu_files(self) -> list[Path]:
+        """List missing user .fmu files that can currently be recovered."""
+        return self._session.user_fmu_directory.list_restorable_files()
+
+    def restore_fmu_files(self) -> list[Path]:
+        """Restore missing user .fmu resources for the current session."""
+        restorable_files = self.get_restorable_fmu_files()
+        if not restorable_files:
+            return []
+
         self._session.user_fmu_directory.restore()
-        if isinstance(self._session, ProjectSession):
-            self._session.project_fmu_directory.restore()
+        return restorable_files
 
     async def add_access_token(self, access_token: AccessToken) -> str:
         """Add a known access token to the session."""

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -31,8 +31,8 @@ from pydantic import ValidationError
 from runrms.exceptions import RmsVersionError
 
 from fmu_settings_api.deps import (
-    ProjectRestoreServiceDep,
     ProjectServiceDep,
+    ProjectServiceForRestoreDep,
     ProjectSessionServiceDep,
     RefreshLockDep,
     ResourceServiceDep,
@@ -1187,7 +1187,7 @@ async def post_cache_restore(
     },
 )
 async def get_restore_check(
-    project_service: ProjectRestoreServiceDep,
+    project_service: ProjectServiceForRestoreDep,
 ) -> RestorableFilesResponse:
     """List recoverable missing project .fmu files for the current session."""
     return RestorableFilesResponse(files=project_service.get_restorable_fmu_files())
@@ -1209,7 +1209,7 @@ async def get_restore_check(
     },
 )
 async def post_restore(
-    project_service: ProjectRestoreServiceDep,
+    project_service: ProjectServiceForRestoreDep,
 ) -> RestorableFilesResponse:
     """Attempt recovery of missing project .fmu files."""
     try:

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -31,6 +31,7 @@ from pydantic import ValidationError
 from runrms.exceptions import RmsVersionError
 
 from fmu_settings_api.deps import (
+    ProjectRestoreServiceDep,
     ProjectServiceDep,
     ProjectSessionServiceDep,
     RefreshLockDep,
@@ -40,7 +41,12 @@ from fmu_settings_api.deps import (
 )
 from fmu_settings_api.deps.changelog import ChangelogServiceDep
 from fmu_settings_api.deps.mappings import MappingsServiceDep
-from fmu_settings_api.models import FMUDirPath, FMUProject, Message
+from fmu_settings_api.models import (
+    FMUDirPath,
+    FMUProject,
+    Message,
+    RestorableFilesResponse,
+)
 from fmu_settings_api.models.common import Ok
 from fmu_settings_api.models.project import (
     CacheRetention,
@@ -1163,6 +1169,62 @@ async def post_cache_restore(
             detail=(
                 f"Permission denied accessing .fmu at {resource_service.fmu_dir_path}"
             ),
+        ) from e
+
+
+@router.get(
+    "/restore/check",
+    response_model=RestorableFilesResponse,
+    summary="Checks which missing project .fmu resources can be restored",
+    description=dedent(
+        """
+        Lists recoverable missing project .fmu content from in-memory state.
+        """
+    ),
+    responses={
+        **GetSessionResponses,
+        **ProjectResponses,
+    },
+)
+async def get_restore_check(
+    project_service: ProjectRestoreServiceDep,
+) -> RestorableFilesResponse:
+    """List recoverable missing project .fmu files for the current session."""
+    return RestorableFilesResponse(files=project_service.get_restorable_fmu_files())
+
+
+@router.post(
+    "/restore",
+    response_model=RestorableFilesResponse,
+    summary="Restores missing project .fmu resources for the current session",
+    description=dedent(
+        """
+        Attempts to recover missing project .fmu content from in-memory state.
+        """
+    ),
+    responses={
+        **GetSessionResponses,
+        **ProjectResponses,
+        **LockConflictResponses,
+    },
+)
+async def post_restore(
+    project_service: ProjectRestoreServiceDep,
+) -> RestorableFilesResponse:
+    """Attempt recovery of missing project .fmu files."""
+    try:
+        return RestorableFilesResponse(files=project_service.restore_fmu_files())
+    except FileExistsError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    except PermissionError as e:
+        if "Cannot write to .fmu directory because it is locked by" in str(e):
+            raise HTTPException(
+                status_code=423,
+                detail=f"Project lock conflict: {e}",
+            ) from e
+        raise HTTPException(
+            status_code=403,
+            detail=f"Permission denied accessing .fmu at {project_service.config_path}",
         ) from e
 
 

--- a/src/fmu_settings_api/v1/routes/session.py
+++ b/src/fmu_settings_api/v1/routes/session.py
@@ -15,7 +15,12 @@ from fmu_settings_api.deps import (
     UserFMUDirDep,
 )
 from fmu_settings_api.deps.session import DestroySessionIfExpiredDep
-from fmu_settings_api.models import AccessToken, Message, SessionResponse
+from fmu_settings_api.models import (
+    AccessToken,
+    Message,
+    RestorableFilesResponse,
+    SessionResponse,
+)
 from fmu_settings_api.session import (
     SessionNotFoundError,
     add_fmu_project_to_session,
@@ -42,11 +47,6 @@ SessionRestoreResponses = {
         409,
         "A .fmu path exists but is not a directory",
         [{"detail": ".fmu exists at {path} but is not a directory"}],
-    ),
-    **inline_add_response(
-        423,
-        "Project is locked by another process and cannot be restored",
-        [{"detail": "Project lock conflict: {error_message}"}],
     ),
 }
 
@@ -192,35 +192,45 @@ async def get_session(
     return session_service.get_session_response()
 
 
-@router.post(
-    "/restore",
-    response_model=Message,
-    summary="Restores missing .fmu resources for the current session",
+@router.get(
+    "/restore/check",
+    response_model=RestorableFilesResponse,
+    summary="Checks which missing user .fmu resources can be restored",
     description=dedent(
         """
-        Attempts to recover missing .fmu content from in-memory state.
+        Lists recoverable missing user .fmu content from in-memory state.
+        """
+    ),
+    responses=GetSessionResponses,
+)
+async def get_restore_check(
+    session_service: SessionServiceDep,
+) -> RestorableFilesResponse:
+    """List recoverable missing user .fmu files for the current session."""
+    return RestorableFilesResponse(files=session_service.get_restorable_fmu_files())
 
-        For all sessions this restores the user .fmu directory. If a project is
-        attached to the session, the project .fmu directory is restored as well.
+
+@router.post(
+    "/restore",
+    response_model=RestorableFilesResponse,
+    summary="Restores missing user .fmu resources for the current session",
+    description=dedent(
+        """
+        Attempts to recover missing user .fmu content from in-memory state.
         """
     ),
     responses={**GetSessionResponses, **SessionRestoreResponses},
 )
-async def post_restore(session_service: SessionServiceDep) -> Message:
-    """Attempt recovery of missing .fmu directories."""
+async def post_restore(
+    session_service: SessionServiceDep,
+) -> RestorableFilesResponse:
+    """Attempt recovery of missing user .fmu files."""
     try:
-        session_service.restore_fmu_directories()
+        return RestorableFilesResponse(files=session_service.restore_fmu_files())
     except FileExistsError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
     except PermissionError as e:
-        if "Cannot write to .fmu directory because it is locked by" in str(e):
-            raise HTTPException(
-                status_code=423,
-                detail=f"Project lock conflict: {e}",
-            ) from e
         raise HTTPException(
             status_code=403,
             detail="Permission denied recovering .fmu resources",
         ) from e
-
-    return Message(message="Restored .fmu resources")

--- a/tests/test_services/test_project_service.py
+++ b/tests/test_services/test_project_service.py
@@ -44,6 +44,17 @@ def test_update_cache_max_revisions_success(fmu_dir: ProjectFMUDirectory) -> Non
     assert fmu_dir.config.load(force=True).cache_max_revisions == updated_value
 
 
+def test_restore_fmu_files_returns_empty_without_calling_restore(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Test restore_fmu_files returns early when nothing is restorable."""
+    service = ProjectService(fmu_dir)
+
+    with patch.object(fmu_dir, "restore") as mock_restore:
+        assert service.restore_fmu_files() == []
+        mock_restore.assert_not_called()
+
+
 def test_update_rms_saves_path_and_version(fmu_dir: ProjectFMUDirectory) -> None:
     """Test that update_rms saves the RMS project path and version."""
     rms_project_path = Path("/path/to/rms/project.rms14.2.2")

--- a/tests/test_v1/test_deps.py
+++ b/tests/test_v1/test_deps.py
@@ -23,7 +23,7 @@ from fmu_settings_api.deps.permissions import (
 )
 from fmu_settings_api.deps.project import (
     get_project_service,
-    get_restore_project_service,
+    get_project_service_for_restore,
 )
 from fmu_settings_api.deps.session import (
     get_project_session,
@@ -393,7 +393,7 @@ async def test_get_restore_project_service_requires_project_session(
     session = await get_fmu_session(session_id)
 
     with pytest.raises(HTTPException, match="401: No FMU project directory open"):
-        await get_restore_project_service(session)
+        await get_project_service_for_restore(session)
 
 
 async def test_refresh_lock_dep_refreshes_lock_when_acquired(

--- a/tests/test_v1/test_deps.py
+++ b/tests/test_v1/test_deps.py
@@ -21,7 +21,10 @@ from fmu_settings_api.deps.permissions import (
     check_write_permissions,
     refresh_project_lock_dep,
 )
-from fmu_settings_api.deps.project import get_project_service
+from fmu_settings_api.deps.project import (
+    get_project_service,
+    get_restore_project_service,
+)
 from fmu_settings_api.deps.session import (
     get_project_session,
     get_project_session_service,
@@ -378,6 +381,19 @@ async def test_get_project_service_returns_project_service(
     assert isinstance(project_service, ProjectService)
     assert project_service._fmu_dir == project_fmu_dir
     assert project_service._fmu_dir.path == project_fmu_dir.path
+
+
+async def test_get_restore_project_service_requires_project_session(
+    tmp_path_mocked_home: Path,
+    session_manager: SessionManager,
+) -> None:
+    """Tests that get_restore_project_service rejects plain user sessions."""
+    user_fmu_dir = init_user_fmu_directory()
+    session_id = await create_fmu_session(user_fmu_dir)
+    session = await get_fmu_session(session_id)
+
+    with pytest.raises(HTTPException, match="401: No FMU project directory open"):
+        await get_restore_project_service(session)
 
 
 async def test_refresh_lock_dep_refreshes_lock_when_acquired(

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -3986,3 +3986,154 @@ async def test_post_cache_restore_resource_permission_error(
     assert response.json() == {
         "detail": f"Permission denied accessing .fmu at {fmu_dir.path}"
     }
+
+
+# GET project/restore/check #
+
+
+async def test_get_restore_check_lists_recoverable_project_files(
+    client_with_project_session: TestClient,
+    session_manager: SessionManager,
+) -> None:
+    """Tests GET /project/restore/check reports recoverable project .fmu files."""
+    session_id = client_with_project_session.cookies.get(
+        settings.SESSION_COOKIE_KEY, None
+    )
+    assert session_id is not None
+    session = await session_manager.get_session(session_id)
+    assert isinstance(session, ProjectSession)
+
+    project_fmu_path = session.project_fmu_directory.path
+    shutil.rmtree(project_fmu_path)
+
+    response = client_with_project_session.get(f"{ROUTE}/restore/check")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {"files": ["README", "config.json"]}
+
+
+async def test_get_restore_check_reports_no_recoverable_project_files(
+    client_with_project_session: TestClient,
+) -> None:
+    """Tests GET /project/restore/check reports empty results when no files missing."""
+    response = client_with_project_session.get(f"{ROUTE}/restore/check")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {"files": []}
+
+
+# POST project/restore #
+
+
+async def test_post_restore_restores_project_fmu_directory(
+    client_with_project_session: TestClient,
+    session_manager: SessionManager,
+) -> None:
+    """Tests POST /project/restore recovers a deleted project .fmu directory."""
+    session_id = client_with_project_session.cookies.get(
+        settings.SESSION_COOKIE_KEY, None
+    )
+    assert session_id is not None
+    session = await session_manager.get_session(session_id)
+    assert isinstance(session, ProjectSession)
+
+    project_fmu_path = session.project_fmu_directory.path
+    assert project_fmu_path.exists()
+
+    shutil.rmtree(project_fmu_path)
+    assert not project_fmu_path.exists()
+
+    response = client_with_project_session.post(f"{ROUTE}/restore")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {"files": ["README", "config.json"]}
+    assert project_fmu_path.exists()
+    assert session.project_fmu_directory.config.path.exists()
+
+
+async def test_post_restore_returns_restored_mappings_file(
+    client_with_project_session: TestClient,
+    session_manager: SessionManager,
+    make_stratigraphy_mappings: Callable[[], StratigraphyMappings],
+) -> None:
+    """Tests POST /project/restore reports project-only files like mappings.json."""
+    session_id = client_with_project_session.cookies.get(
+        settings.SESSION_COOKIE_KEY, None
+    )
+    assert session_id is not None
+    session = await session_manager.get_session(session_id)
+    assert isinstance(session, ProjectSession)
+
+    fmu_dir = session.project_fmu_directory
+    mappings = make_stratigraphy_mappings()
+    fmu_dir.mappings.update_stratigraphy_mappings(mappings)
+
+    mappings_path = fmu_dir.mappings.path
+    assert mappings_path.exists()
+    mappings_path.unlink()
+    assert not mappings_path.exists()
+
+    response = client_with_project_session.post(f"{ROUTE}/restore")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {"files": ["mappings.json"]}
+    assert mappings_path.exists()
+    assert fmu_dir.mappings.stratigraphy_mappings == mappings
+
+
+def test_post_restore_returns_conflict(
+    client_with_project_session: TestClient,
+) -> None:
+    """Tests POST /project/restore returns 409 when .fmu is not a directory."""
+    error = ".fmu exists at /tmp/example but is not a directory"
+    with patch(
+        "fmu_settings_api.services.project.ProjectService.restore_fmu_files",
+        side_effect=FileExistsError(error),
+    ):
+        response = client_with_project_session.post(f"{ROUTE}/restore")
+
+    assert response.status_code == status.HTTP_409_CONFLICT, response.json()
+    assert response.json()["detail"] == error
+
+
+def test_post_restore_returns_lock_conflict(
+    client_with_project_session: TestClient,
+) -> None:
+    """Tests POST /project/restore returns 423 on project lock conflicts."""
+    error = (
+        "Cannot write to .fmu directory because it is locked by "
+        "someone@somehost (PID: 1234). Lock expires at Mon Jan  1 00:00:00 2030."
+    )
+    with patch(
+        "fmu_settings_api.services.project.ProjectService.restore_fmu_files",
+        side_effect=PermissionError(error),
+    ):
+        response = client_with_project_session.post(f"{ROUTE}/restore")
+
+    assert response.status_code == status.HTTP_423_LOCKED, response.json()
+    assert response.json()["detail"] == f"Project lock conflict: {error}"
+
+
+async def test_post_restore_returns_permission_denied(
+    client_with_project_session: TestClient,
+    session_manager: SessionManager,
+) -> None:
+    """Tests POST /project/restore returns 403 on permission issues."""
+    session_id = client_with_project_session.cookies.get(
+        settings.SESSION_COOKIE_KEY, None
+    )
+    assert session_id is not None
+    session = await session_manager.get_session(session_id)
+    assert isinstance(session, ProjectSession)
+
+    with patch(
+        "fmu_settings_api.services.project.ProjectService.restore_fmu_files",
+        side_effect=PermissionError("Permission denied"),
+    ):
+        response = client_with_project_session.post(f"{ROUTE}/restore")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
+    assert response.json()["detail"] == (
+        f"Permission denied accessing .fmu at "
+        f"{session.project_fmu_directory.config.path}"
+    )

--- a/tests/test_v1/test_session.py
+++ b/tests/test_v1/test_session.py
@@ -568,6 +568,39 @@ async def test_patch_access_token_unknown_failure(
         assert response.json()["detail"] == "An unexpected error occurred."
 
 
+# GET session/restore/check #
+
+
+async def test_get_restore_check_session_lists_recoverable_user_files(
+    client_with_session: TestClient,
+    session_manager: SessionManager,
+) -> None:
+    """Tests GET /session/restore/check reports recoverable user .fmu files."""
+    session_id = client_with_session.cookies.get(settings.SESSION_COOKIE_KEY)
+    assert session_id is not None
+
+    session = await session_manager.get_session(session_id)
+    shutil.rmtree(session.user_fmu_directory.path)
+
+    response = client_with_session.get(f"{ROUTE}/restore/check")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {"files": ["README", "config.json"]}
+
+
+async def test_get_restore_check_session_reports_no_recoverable_files(
+    client_with_project_session: TestClient,
+) -> None:
+    """Tests GET /session/restore/check reports no recoverable files."""
+    response = client_with_project_session.get(f"{ROUTE}/restore/check")
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {"files": []}
+
+
+# POST session/restore #
+
+
 async def test_post_restore_session_restores_user_fmu_directory(
     client_with_session: TestClient,
     session_manager: SessionManager,
@@ -585,25 +618,23 @@ async def test_post_restore_session_restores_user_fmu_directory(
 
     response = client_with_session.post(f"{ROUTE}/restore")
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.json()["message"] == "Restored .fmu resources"
+    assert response.json() == {"files": ["README", "config.json"]}
     assert user_fmu_path.exists()
     assert session.user_fmu_directory.config.path.exists()
 
 
-async def test_post_restore_session_restores_project_fmu_directory(
+async def test_post_restore_session_does_not_restore_project_fmu_directory(
     client_with_project_session: TestClient,
     session_manager: SessionManager,
 ) -> None:
-    """Tests POST /session/restore recovers a deleted project .fmu directory."""
+    """Tests POST /session/restore only recovers deleted user .fmu files."""
     session_id = client_with_project_session.cookies.get(settings.SESSION_COOKIE_KEY)
     assert session_id is not None
 
     session = await session_manager.get_session(session_id)
     assert isinstance(session, ProjectSession)
 
-    user_fmu_path = session.user_fmu_directory.path
     project_fmu_path = session.project_fmu_directory.path
-    assert user_fmu_path.exists()
     assert project_fmu_path.exists()
 
     shutil.rmtree(project_fmu_path)
@@ -611,27 +642,8 @@ async def test_post_restore_session_restores_project_fmu_directory(
 
     response = client_with_project_session.post(f"{ROUTE}/restore")
     assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.json()["message"] == "Restored .fmu resources"
-    assert project_fmu_path.exists()
-    assert session.project_fmu_directory.config.path.exists()
-
-
-def test_post_restore_session_returns_lock_conflict_for_project(
-    client_with_project_session: TestClient,
-) -> None:
-    """Tests POST /session/restore returns 423 on project lock conflicts."""
-    error = (
-        "Cannot write to .fmu directory because it is locked by "
-        "someone@somehost (PID: 1234). Lock expires at Mon Jan  1 00:00:00 2030."
-    )
-    with patch(
-        "fmu_settings_api.services.session.SessionService.restore_fmu_directories",
-        side_effect=PermissionError(error),
-    ):
-        response = client_with_project_session.post(f"{ROUTE}/restore")
-
-    assert response.status_code == status.HTTP_423_LOCKED, response.json()
-    assert response.json()["detail"] == f"Project lock conflict: {error}"
+    assert response.json() == {"files": []}
+    assert not project_fmu_path.exists()
 
 
 def test_post_restore_session_returns_permission_denied(
@@ -639,7 +651,7 @@ def test_post_restore_session_returns_permission_denied(
 ) -> None:
     """Tests POST /session/restore returns 403 on permission issues."""
     with patch(
-        "fmu_settings_api.services.session.SessionService.restore_fmu_directories",
+        "fmu_settings_api.services.session.SessionService.restore_fmu_files",
         side_effect=PermissionError("Permission denied"),
     ):
         response = client_with_session.post(f"{ROUTE}/restore")
@@ -654,7 +666,7 @@ def test_post_restore_session_returns_conflict(
     """Tests POST /session/restore returns 409 when .fmu is not a directory."""
     error = ".fmu exists at /tmp/example but is not a directory"
     with patch(
-        "fmu_settings_api.services.session.SessionService.restore_fmu_directories",
+        "fmu_settings_api.services.session.SessionService.restore_fmu_files",
         side_effect=FileExistsError(error),
     ):
         response = client_with_session.post(f"{ROUTE}/restore")


### PR DESCRIPTION
Resolves #336 

Feedback from joar for this [PR](https://github.com/equinor/fmu-settings-gui/pull/269) in GUI:
1. First comment (ref [here](https://github.com/equinor/fmu-settings-gui/pull/269#discussion_r2918795068)): We need to check if there's any missing/deleted files before restoring, so we don't need to restore if there's no missing files, and we can tell the users what files are restored if there's any.
2. Second comment (ref [here](https://github.com/equinor/fmu-settings-gui/pull/269#discussion_r2918970887)): It's better to split the restore flow for user .fmu and project .fmu files, so the project page only restore project .fmu files and we can have a separate page to restore user .fmu files.

This PR added two endpoints (`GET /restore/check` and `POST /restore`) to both project route and session route to check restorable files and to restore missing files.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
