### PR TITLE
ENH: Add UUID-based SMDA lookup and country to field search

### DIFF
--- a/src/fmu_settings_api/interfaces/smda_api.py
+++ b/src/fmu_settings_api/interfaces/smda_api.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Sequence
 from typing import Any, Final
+from uuid import UUID
 
 import httpx
 
@@ -72,14 +73,23 @@ class SmdaAPI:
         return res.status_code == httpx.codes.OK
 
     async def field(
-        self, field_identifiers: Sequence[str], columns: Sequence[str] | None = None
+        self,
+        field_identifiers: Sequence[str] | None = None,
+        field_uuid: UUID | None = None,
+        columns: Sequence[str] | None = None,
     ) -> httpx.Response:
         """Searches for a field identifier in SMDA."""
         _projection = "identifier,uuid" if columns is None else ",".join(columns)
+        json: dict[str, Any] = {"_projection": _projection}
+
+        if field_identifiers:
+            json["identifier"] = field_identifiers
+        if field_uuid is not None:
+            json["uuid"] = [str(field_uuid)]
 
         return await self.post(
             SmdaRoutes.FIELDS_SEARCH,
-            json={"_projection": _projection, "identifier": field_identifiers},
+            json=json,
         )
 
     async def country(

--- a/src/fmu_settings_api/models/smda.py
+++ b/src/fmu_settings_api/models/smda.py
@@ -22,6 +22,16 @@ class SmdaField(BaseResponseModel):
     """A field identifier (name)."""
 
 
+class SmdaSelectedField(BaseResponseModel):
+    """A selected field for masterdata lookup."""
+
+    identifier: str = Field(examples=["TROLL"])
+    """A field identifier (name)."""
+
+    uuid: UUID | None = None
+    """The SMDA UUID identifier corresponding to the field identifier."""
+
+
 class SmdaStratColumn(BaseResponseModel):
     """An identifier for a stratigraphic column."""
 
@@ -37,6 +47,9 @@ class SmdaFieldUUID(BaseResponseModel):
 
     uuid: UUID
     """The SMDA UUID identifier corresponding to the field identifier."""
+
+    country: str
+    """The country identifier corresponding to the field identifier."""
 
 
 class SmdaFieldSearchResult(BaseResponseModel):

--- a/src/fmu_settings_api/services/smda.py
+++ b/src/fmu_settings_api/services/smda.py
@@ -88,9 +88,13 @@ class SmdaService:
 
         if not field_results:
             requested_identifiers = [field.identifier for field in smda_fields]
-            raise ValueError(
-                f"No fields found for identifiers: {requested_identifiers}"
-            )
+            requested_uuids = [
+                str(field.uuid) for field in smda_fields if field.uuid is not None
+            ]
+            error_msg = f"No fields found for identifiers: {requested_identifiers}"
+            if requested_uuids:
+                error_msg += f" and UUIDs: {requested_uuids}"
+            raise ValueError(error_msg)
 
         field_items = [FieldItem.model_validate(field) for field in field_results]
         field_identifiers = [field.identifier for field in field_items]

--- a/src/fmu_settings_api/services/smda.py
+++ b/src/fmu_settings_api/services/smda.py
@@ -16,6 +16,7 @@ from fmu_settings_api.models.smda import (
     SmdaField,
     SmdaFieldSearchResult,
     SmdaMasterdataResult,
+    SmdaSelectedField,
     SmdaStratigraphicUnitsResult,
     StratigraphicUnit,
 )
@@ -35,34 +36,60 @@ class SmdaService:
 
     async def search_field(self, field: SmdaField) -> SmdaFieldSearchResult:
         """Search for a field identifier in SMDA."""
-        res = await self._smda.field([field.identifier])
+        res = await self._smda.field(
+            [field.identifier],
+            columns=["country_identifier", "identifier", "uuid"],
+        )
         data = res.json()["data"]
+        data["results"] = [
+            {
+                "identifier": result["identifier"],
+                "uuid": result["uuid"],
+                "country": result["country_identifier"],
+            }
+            for result in data["results"]
+        ]
         return SmdaFieldSearchResult(**data)
 
     async def get_masterdata(
-        self, smda_fields: list[SmdaField]
+        self, smda_fields: list[SmdaSelectedField]
     ) -> SmdaMasterdataResult:
         """Retrieve masterdata for fields to be confirmed in the GUI."""
         if not smda_fields:
             raise ValueError("At least one SMDA field must be provided")
 
-        # Sorted for tests as sets don't guarantee order
-        unique_field_identifiers = sorted({field.identifier for field in smda_fields})
+        if smda_fields[0].uuid is not None:
+            field_res = await self._smda.field(
+                field_uuid=smda_fields[0].uuid,
+                columns=[
+                    "country_identifier",
+                    "identifier",
+                    "projected_coordinate_system",
+                    "uuid",
+                ],
+            )
+            field_results = field_res.json()["data"]["results"]
+        else:
+            # Sorted for tests as sets don't guarantee order
+            unique_field_identifiers = sorted(
+                {field.identifier for field in smda_fields}
+            )
+            # Query initial list of fields (with duplicates removed)
+            field_res = await self._smda.field(
+                unique_field_identifiers,
+                columns=[
+                    "country_identifier",
+                    "identifier",
+                    "projected_coordinate_system",
+                    "uuid",
+                ],
+            )
+            field_results = field_res.json()["data"]["results"]
 
-        # Query initial list of fields (with duplicates removed)
-        field_res = await self._smda.field(
-            unique_field_identifiers,
-            columns=[
-                "country_identifier",
-                "identifier",
-                "projected_coordinate_system",
-                "uuid",
-            ],
-        )
-        field_results = field_res.json()["data"]["results"]
         if not field_results:
+            requested_identifiers = [field.identifier for field in smda_fields]
             raise ValueError(
-                f"No fields found for identifiers: {unique_field_identifiers}"
+                f"No fields found for identifiers: {requested_identifiers}"
             )
 
         field_items = [FieldItem.model_validate(field) for field in field_results]

--- a/src/fmu_settings_api/v1/routes/smda/main.py
+++ b/src/fmu_settings_api/v1/routes/smda/main.py
@@ -143,13 +143,13 @@ async def get_health(smda_service: SmdaServiceDep) -> Ok:
     summary="Searches for a field identifier in SMDA",
     description=dedent(
         """
-        A route to search SMDA for an field (asset) by its named identifier.
+        A route to search SMDA for a field (asset) by its named identifier.
 
         This endpoint applies a projection to the SMDA query so that only the relevant
         data is returned: an identifier known by SMDA, its corresponding UUID, and the
-        country the field belongs to. The UUID should be used by other endpoints
-        required the collection of data by a field, i.e. this route is a dependency for
-        most other routes.
+        main country the field belongs to, not a list of countries where the field
+        exists. The UUID should be used by other endpoints required the collection of
+        data by a field, i.e. this route is a dependency for most other routes.
 
         The number of results (hits) and number of pages those results span over is also
         returned in the result. This endpoint does not implement pagination. The

--- a/src/fmu_settings_api/v1/routes/smda/main.py
+++ b/src/fmu_settings_api/v1/routes/smda/main.py
@@ -17,6 +17,7 @@ from fmu_settings_api.models.smda import (
     SmdaField,
     SmdaFieldSearchResult,
     SmdaMasterdataResult,
+    SmdaSelectedField,
     SmdaStratColumn,
     SmdaStratigraphicUnitsResult,
 )
@@ -145,9 +146,10 @@ async def get_health(smda_service: SmdaServiceDep) -> Ok:
         A route to search SMDA for an field (asset) by its named identifier.
 
         This endpoint applies a projection to the SMDA query so that only the relevant
-        data is returned: an identifier known by SMDA and its corresponding UUID. The
-        UUID should be used by other endpoints required the collection of data by a
-        field, i.e. this route is a dependency for most other routes.
+        data is returned: an identifier known by SMDA, its corresponding UUID, and the
+        country the field belongs to. The UUID should be used by other endpoints
+        required the collection of data by a field, i.e. this route is a dependency for
+        most other routes.
 
         The number of results (hits) and number of pages those results span over is also
         returned in the result. This endpoint does not implement pagination. The
@@ -209,8 +211,9 @@ async def post_field(
         A route to gather prospective SMDA masterdata relevant to FMU.
 
         This route receives a list of valid field names and returns masterdata that
-        pertains to them. The field names should be valid as return from from the
-        `smda/field` routes.
+        pertains to them. The field names should be valid as returned from the
+        `smda/field` route. Callers may also provide a field UUID to disambiguate
+        fields that share the same identifier.
 
         The data returned from this endpoint is meant to be confirmed by the user who
         may need to do some additional selection or pruning based upon the model they
@@ -232,7 +235,7 @@ async def post_field(
     },
 )
 async def post_masterdata(
-    smda_fields: list[SmdaField],
+    smda_fields: list[SmdaSelectedField],
     smda_service: ProjectSmdaServiceDep,
 ) -> SmdaMasterdataResult:
     """Queries SMDA masterdata for .fmu project configuration."""

--- a/src/fmu_settings_api/v1/routes/smda/main.py
+++ b/src/fmu_settings_api/v1/routes/smda/main.py
@@ -213,7 +213,10 @@ async def post_field(
         This route receives a list of valid field names and returns masterdata that
         pertains to them. The field names should be valid as returned from the
         `smda/field` route. Callers may also provide a field UUID to disambiguate
-        fields that share the same identifier.
+        fields that share the same identifier. If the first field does not include
+        a UUID, the endpoint searches for all provided field identifiers. If the
+        first field includes a UUID, the endpoint looks up only that field, even if
+        more fields are included in the request.
 
         The data returned from this endpoint is meant to be confirmed by the user who
         may need to do some additional selection or pruning based upon the model they

--- a/tests/test_interfaces/test_smda_api.py
+++ b/tests/test_interfaces/test_smda_api.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import httpx
 import pytest
@@ -218,6 +219,24 @@ async def test_smda_field_search(mock_httpx_post: MagicMock) -> None:
         json={
             "_projection": "identifier,uuid",
             "identifier": ["FIELD_A"],
+        },
+    )
+    res.raise_for_status.assert_called_once()  # type: ignore
+
+
+async def test_smda_field_search_with_uuid(mock_httpx_post: MagicMock) -> None:
+    """Tests field search can query using UUIDs."""
+    api = SmdaAPI("token", "key")
+    field_uuid = UUID("c8da9f15-f7d9-4d47-a2a3-60e34e9d15d7")
+
+    res = await api.field(field_uuid=field_uuid)
+
+    mock_httpx_post.assert_called_with(
+        f"{SmdaRoutes.BASE_URL}/{SmdaRoutes.FIELDS_SEARCH}",
+        headers=api._headers,
+        json={
+            "_projection": "identifier,uuid",
+            "uuid": ["c8da9f15-f7d9-4d47-a2a3-60e34e9d15d7"],
         },
     )
     res.raise_for_status.assert_called_once()  # type: ignore

--- a/tests/test_services/test_smda_service.py
+++ b/tests/test_services/test_smda_service.py
@@ -12,7 +12,7 @@ from fmu.datamodels.common.masterdata import (
     StratigraphicColumn,
 )
 
-from fmu_settings_api.models.smda import SmdaField
+from fmu_settings_api.models.smda import SmdaField, SmdaSelectedField
 from fmu_settings_api.services.smda import SmdaService
 
 
@@ -400,6 +400,108 @@ async def test_get_masterdata_no_fields_found() -> None:
     service = SmdaService(mock_smda)
 
     with pytest.raises(ValueError) as exc_info:
-        await service.get_masterdata([SmdaField(identifier="NONEXISTENT")])
+        await service.get_masterdata([SmdaSelectedField(identifier="NONEXISTENT")])
 
     assert "No fields found for identifiers" in str(exc_info.value)
+
+
+async def test_search_field_adds_country_to_results() -> None:
+    """Tests that field search exposes country in each result row."""
+    mock_smda = AsyncMock()
+    field_resp = MagicMock()
+    field_uuid = uuid4()
+    field_resp.json.return_value = {
+        "data": {
+            "hits": 1,
+            "pages": 1,
+            "results": [
+                {
+                    "country_identifier": "Norway",
+                    "identifier": "DROGON",
+                    "uuid": field_uuid,
+                }
+            ],
+        }
+    }
+    mock_smda.field.return_value = field_resp
+
+    service = SmdaService(mock_smda)
+    result = await service.search_field(SmdaField(identifier="DROGON"))
+
+    mock_smda.field.assert_called_once_with(
+        ["DROGON"],
+        columns=["country_identifier", "identifier", "uuid"],
+    )
+    assert result.results[0].country == "Norway"
+
+
+async def test_get_masterdata_uses_selected_field_uuid_for_lookup() -> None:
+    """Tests that get_masterdata uses the selected field uuid for lookup."""
+    mock_smda = AsyncMock()
+    selected_uuid = uuid4()
+    field_resp = MagicMock()
+    field_resp.json.return_value = {
+        "data": {
+            "results": [
+                {
+                    "country_identifier": "Norway",
+                    "identifier": "DROGON",
+                    "projected_coordinate_system": "ST_WGS84_UTM37N_P32637",
+                    "uuid": selected_uuid,
+                },
+            ]
+        }
+    }
+    mock_smda.field.return_value = field_resp
+    mock_smda.coordinate_system.return_value = MagicMock(
+        json=MagicMock(
+            return_value={
+                "data": {
+                    "results": [
+                        {
+                            "identifier": "ST_WGS84_UTM37N_P32637",
+                            "uuid": uuid4(),
+                        },
+                        {
+                            "identifier": "ST_WGS84_UTM37N_P32638",
+                            "uuid": uuid4(),
+                        },
+                    ]
+                }
+            }
+        )
+    )
+    mock_smda.country.return_value = MagicMock(
+        json=MagicMock(
+            return_value={
+                "data": {
+                    "results": [
+                        {"identifier": "Norway", "uuid": uuid4()},
+                    ]
+                }
+            }
+        )
+    )
+    mock_smda.discovery.return_value = MagicMock(
+        json=MagicMock(return_value={"data": {"results": []}})
+    )
+    mock_smda.strat_column_areas.return_value = MagicMock(
+        json=MagicMock(return_value={"data": {"results": []}})
+    )
+
+    service = SmdaService(mock_smda)
+    result = await service.get_masterdata(
+        [SmdaSelectedField(identifier="DROGON", uuid=selected_uuid)]
+    )
+
+    mock_smda.field.assert_called_once_with(
+        field_uuid=selected_uuid,
+        columns=[
+            "country_identifier",
+            "identifier",
+            "projected_coordinate_system",
+            "uuid",
+        ],
+    )
+    assert len(result.field) == 1
+    assert result.field[0].uuid == selected_uuid

--- a/tests/test_v1/test_smda.py
+++ b/tests/test_v1/test_smda.py
@@ -136,6 +136,7 @@ async def test_post_field_succeeds_with_one(
             "pages": 1,
             "results": [
                 {
+                    "country_identifier": "Norway",
                     "identifier": "TROLL",
                     "uuid": str(uuid),
                 }
@@ -159,7 +160,7 @@ async def test_post_field_succeeds_with_one(
         hits=1,
         pages=1,
         results=[
-            SmdaFieldUUID(identifier="TROLL", uuid=uuid),
+            SmdaFieldUUID(identifier="TROLL", uuid=uuid, country="Norway"),
         ],
     )
 
@@ -365,6 +366,89 @@ async def test_post_masterdata_success(
 
     mock_smda_instance.field.assert_called_once_with(
         ["DROGON"],
+        columns=[
+            "country_identifier",
+            "identifier",
+            "projected_coordinate_system",
+            "uuid",
+        ],
+    )
+
+
+async def test_post_masterdata_uses_selected_field_uuid_for_lookup(
+    client_with_smda_session: TestClient,
+    session_tmp_path: Path,
+) -> None:
+    """Tests that masterdata requests use the selected field uuid for lookup."""
+    selected_uuid = uuid4()
+    mock_identifier_field_response = MagicMock(spec=httpx.Response)
+    mock_identifier_field_response.status_code = 200
+    mock_identifier_field_response.json.return_value = {
+        "data": {
+            "hits": 1,
+            "pages": 1,
+            "results": [
+                {
+                    "country_identifier": "Norway",
+                    "identifier": "DROGON",
+                    "projected_coordinate_system": "ST_WGS84_UTM37N_P32637",
+                    "uuid": selected_uuid,
+                },
+            ],
+        }
+    }
+
+    with (
+        patch("fmu_settings_api.deps.smda.SmdaAPI") as mock_smda_class,
+        patch(
+            "fmu_settings_api.services.smda.SmdaService._get_coordinate_systems",
+            new_callable=AsyncMock,
+        ) as mock_get_coordinate_systems,
+        patch(
+            "fmu_settings_api.services.smda.SmdaService._get_countries",
+            new_callable=AsyncMock,
+        ) as mock_get_countries,
+        patch(
+            "fmu_settings_api.services.smda.SmdaService._get_discoveries",
+            new_callable=AsyncMock,
+        ) as mock_get_discoveries,
+        patch(
+            "fmu_settings_api.services.smda.SmdaService._get_strat_column_areas",
+            new_callable=AsyncMock,
+        ) as mock_get_strat_column_areas,
+    ):
+        mock_smda_instance = AsyncMock()
+        mock_smda_instance.field.return_value = mock_identifier_field_response
+        mock_smda_class.return_value = mock_smda_instance
+
+        mock_get_coordinate_systems.return_value = [
+            CoordinateSystem(
+                identifier="ST_WGS84_UTM37N_P32637",
+                uuid=uuid4(),
+            ),
+            CoordinateSystem(
+                identifier="ST_WGS84_UTM37N_P32638",
+                uuid=uuid4(),
+            ),
+        ]
+        mock_get_countries.return_value = [
+            CountryItem(identifier="Norway", uuid=uuid4())
+        ]
+        mock_get_discoveries.return_value = []
+        mock_get_strat_column_areas.return_value = []
+        response = client_with_smda_session.post(
+            f"{ROUTE}/masterdata",
+            json=[{"identifier": "DROGON", "uuid": str(selected_uuid)}],
+        )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    response_data = response.json()
+    assert len(response_data["field"]) == 1
+    assert str(response_data["field"][0]["uuid"]) == str(selected_uuid)
+    assert response_data["country"][0]["identifier"] == "Norway"
+
+    mock_smda_instance.field.assert_called_once_with(
+        field_uuid=selected_uuid,
         columns=[
             "country_identifier",
             "identifier",


### PR DESCRIPTION
Resolves #323 

- Add country to the SMDA field search response (in addition to identifier and uuid).
- Masterdata lookup now accepts a selected field model with an optional uuid, and uses that uuid for exact SMDA lookup when it is provided.

  This is added to solve that Raia field problem. To disambiguate fields that exist in multiple countries, we can search for both the field identifier and country, but it's even better to just use the uuid because it's unique. The idea is for the GUI to display field and country, so the user can select which field they want to do masterdata lookup, but the GUI actually sends the field identifier and the field uuid to the API to search for the correct masterdata.

- The changes in this PR is adapting to the fact that GUI is only sending one field when doing masterdata search (described in this issue #200) so we assume there's only one UUID sent to the POST smda/masterdata and there will be only one result from the search. Separate PR should be made to solve that issue and clarify that the API only support one field instead of list of field (this change would also break the GUI so not desired for now).

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
