### PR TITLE
ENH: Sort strat units by level and top age

### DIFF
--- a/src/fmu_settings_api/interfaces/smda_api.py
+++ b/src/fmu_settings_api/interfaces/smda_api.py
@@ -138,6 +138,7 @@ class SmdaAPI:
             json={
                 "_projection": _projection,
                 "strat_column_identifier": strat_column_identifier,
+                "_sort": ["strat_unit_level", "top_age"],
             },
         )
 

--- a/tests/test_interfaces/test_smda_api.py
+++ b/tests/test_interfaces/test_smda_api.py
@@ -100,6 +100,7 @@ async def test_strat_units_with_identifier(mock_httpx_post: MagicMock) -> None:
         json={
             "_projection": "identifier,uuid",
             "strat_column_identifier": "LITHO_DROGON",
+            "_sort": ["strat_unit_level", "top_age"],
         },
     )
     res.raise_for_status.assert_called_once()  # type: ignore
@@ -123,6 +124,7 @@ async def test_strat_units_with_columns(mock_httpx_post: MagicMock) -> None:
         json={
             "_projection": "identifier,uuid,strat_unit_type",
             "strat_column_identifier": "LITHO_DROGON",
+            "_sort": ["strat_unit_level", "top_age"],
         },
     )
     res.raise_for_status.assert_called_once()  # type: ignore


### PR DESCRIPTION
Resolves #346 

Add default sorting of level and top age to the `POST smda/strat_units` endpoint. SMDA already sort the results by top age by default, and with this added `_sort` attribute to the query, it will now sort it by both level and top age.

Before this change:
```json
[
  { "identifier": "NORDLAND GP.", "strat_unit_level": 1, "top_age": 0.001 },
  { "identifier": "HORDALAND GP.", "strat_unit_level": 1, "top_age": 23 },
  { "identifier": "Hordaland Green Clay TRO", "strat_unit_level": 2, "top_age": 37.5 },
  { "identifier": "ROGALAND GP.", "strat_unit_level": 1, "top_age": 52 },
  { "identifier": "Balder Fm.", "strat_unit_level": 2, "top_age": 52 },
  { "identifier": "SHETLAND GP.", "strat_unit_level": 1, "top_age": 64 }
]
```

After this change:
```json
[
  { "identifier": "NORDLAND GP.", "strat_unit_level": 1, "top_age": 0.001 },
  { "identifier": "HORDALAND GP.", "strat_unit_level": 1, "top_age": 23 },
  { "identifier": "ROGALAND GP.", "strat_unit_level": 1, "top_age": 52 },
  { "identifier": "SHETLAND GP.", "strat_unit_level": 1, "top_age": 64 },
  { "identifier": "Hordaland Green Clay TRO", "strat_unit_level": 2, "top_age": 37.5 },
  { "identifier": "Balder Fm.", "strat_unit_level": 2, "top_age": 52 }
]
```

Small notes: SMDA docs says `_sort` can be `array` or `string`, so both of these work: `"_sort": ["strat_unit_level", "top_age"]` and `"_sort": "strat_unit_level,top_age"`. I just chose `array` for clarity.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
