### PR TITLE
BUG: Fix mappings first write behavior

### DIFF
--- a/src/fmu_settings_api/services/mappings.py
+++ b/src/fmu_settings_api/services/mappings.py
@@ -159,7 +159,10 @@ class MappingsService:
         self.build_mapping_groups(new_mappings)
 
         if mapping_type == MappingType.stratigraphy:
-            all_mappings = self.list_stratigraphy_mappings()
+            try:
+                all_mappings = self.list_stratigraphy_mappings()
+            except FileNotFoundError:
+                all_mappings = StratigraphyMappings(root=[])
 
             other_mappings = [
                 mapping

--- a/tests/test_services/test_mappings_service.py
+++ b/tests/test_services/test_mappings_service.py
@@ -149,3 +149,33 @@ def test_update_mappings_by_systems_mapping_group_validation_error(
             DataSystem.smda,
             [primary, alias, alias_to_duplicate],
         )
+
+
+def test_update_mappings_by_systems_creates_mappings_file_if_missing(
+    mappings_service: MappingsService,
+    fmu_dir: ProjectFMUDirectory,
+    make_stratigraphy_mapping: Callable[
+        [str, str, RelationType], StratigraphyIdentifierMapping
+    ],
+) -> None:
+    """Test first-time mapping updates create mappings.json instead of failing."""
+    mappings_path = fmu_dir.mappings.path
+    assert not mappings_path.exists()
+
+    primary = make_stratigraphy_mapping(
+        "TopVolantis",
+        "VOLANTIS GP. Top",
+        RelationType.primary,
+    )
+
+    mappings_service.update_mappings_by_systems(
+        MappingType.stratigraphy,
+        DataSystem.rms,
+        DataSystem.smda,
+        [primary],
+    )
+
+    assert mappings_path.exists()
+    assert fmu_dir.mappings.stratigraphy_mappings == StratigraphyMappings(
+        root=[primary]
+    )

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -3312,6 +3312,43 @@ async def test_put_mappings_stratigraphy_success(
     assert "smda" in response_data["message"]
 
 
+async def test_put_mappings_stratigraphy_creates_file_if_missing(
+    client_with_project_session: TestClient,
+    session_manager: SessionManager,
+    make_stratigraphy_mapping: Callable[..., StratigraphyIdentifierMapping],
+) -> None:
+    """Test PUT creates mappings.json when saving mappings for the first time."""
+    session_id = client_with_project_session.cookies.get(
+        settings.SESSION_COOKIE_KEY, None
+    )
+    assert session_id is not None
+    session = await get_fmu_session(session_id)
+    assert isinstance(session, ProjectSession)
+
+    fmu_dir = session.project_fmu_directory
+    mappings_path = fmu_dir.mappings.path
+    assert not mappings_path.exists()
+
+    mapping = make_stratigraphy_mapping(
+        "TopVolantis",
+        "VOLANTIS GP. Top",
+        RelationType.primary,
+        source_system=DataSystem.rms,
+        target_system=DataSystem.smda,
+    )
+    payload = [mapping.model_dump(mode="json")]
+
+    response = client_with_project_session.put(
+        f"{ROUTE}/mappings/stratigraphy/rms/smda", json=payload
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert mappings_path.exists()
+    assert fmu_dir.mappings.stratigraphy_mappings == StratigraphyMappings(
+        root=[mapping]
+    )
+
+
 async def test_put_mappings_stratigraphy_preserves_other_systems(
     client_with_project_session: TestClient,
     session_manager: SessionManager,


### PR DESCRIPTION
Resolves #351 

Fix `PUT project/mappings/...` behavior on first call when there's no mappings due to unhandled `FileNotFoundError` when reading the current `mappings.json` on disk.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
