### PR TITLE
ENH: Define response schema for `GET project/mappings/...`

### DIFF
--- a/src/fmu_settings_api/models/__init__.py
+++ b/src/fmu_settings_api/models/__init__.py
@@ -8,6 +8,7 @@ from .common import (
     Ok,
     RestorableFilesResponse,
 )
+from .mappings import IdentifierMappingResponse, MappingGroupResponse
 from .project import FMUDirPath, FMUProject
 from .session import SessionResponse
 
@@ -17,6 +18,8 @@ __all__ = [
     "BaseResponseModel",
     "FMUDirPath",
     "FMUProject",
+    "IdentifierMappingResponse",
+    "MappingGroupResponse",
     "Message",
     "Ok",
     "RestorableFilesResponse",

--- a/src/fmu_settings_api/models/mappings.py
+++ b/src/fmu_settings_api/models/mappings.py
@@ -1,0 +1,49 @@
+"""Models for mappings API responses."""
+
+from uuid import UUID
+
+from fmu.datamodels.context.mappings import DataSystem, MappingType, RelationType
+from fmu.settings.models.mappings import MappingGroup
+from pydantic import Field
+
+from fmu_settings_api.models.common import BaseResponseModel
+
+
+class IdentifierMappingResponse(BaseResponseModel):
+    """A mapping entry exposed by the mappings API."""
+
+    relation_type: RelationType
+    """Relationship between the source identifier and the official identifier."""
+
+    source_id: str
+    """Identifier from the source system."""
+
+    source_uuid: UUID | None = Field(default=None)
+    """Optional UUID associated with the source identifier."""
+
+
+class MappingGroupResponse(BaseResponseModel):
+    """Mappings grouped by official target identifier for API responses."""
+
+    official_name: str
+    """Official target identifier shared by all mappings in the group."""
+
+    target_uuid: UUID | None = Field(default=None)
+    """Optional UUID associated with the official identifier."""
+
+    mapping_type: MappingType
+    """Kind of mapping represented by this group."""
+
+    target_system: DataSystem
+    """Target system that owns the official identifier."""
+
+    source_system: DataSystem
+    """Source system that owns the mapped identifiers."""
+
+    mappings: list[IdentifierMappingResponse]
+    """Mappings that point to the same official identifier."""
+
+    @classmethod
+    def from_mapping_group(cls, mapping_group: MappingGroup) -> "MappingGroupResponse":
+        """Create an API response model from an internal MappingGroup."""
+        return cls.model_validate(mapping_group.model_dump())

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -22,7 +22,6 @@ from fmu.settings._init import (
 from fmu.settings.models.change_info import ChangeInfo
 from fmu.settings.models.diff import ResourceDiff
 from fmu.settings.models.log import Log
-from fmu.settings.models.mappings import MappingGroup
 from fmu.settings.models.project_config import (
     RmsCoordinateSystem,
     RmsWell,
@@ -44,6 +43,7 @@ from fmu_settings_api.deps.mappings import MappingsServiceDep
 from fmu_settings_api.models import (
     FMUDirPath,
     FMUProject,
+    MappingGroupResponse,
     Message,
     RestorableFilesResponse,
 )
@@ -1267,7 +1267,7 @@ async def post_restore(
 
 @router.get(
     "/mappings/{mapping_type}/{source_system}/{target_system}",
-    response_model=list[MappingGroup],
+    response_model=list[MappingGroupResponse],
     summary="Returns mappings for a specific mapping type and system combination.",
     description=dedent(
         """
@@ -1291,12 +1291,15 @@ async def get_mappings(
     mapping_type: MappingType,
     source_system: DataSystem,
     target_system: DataSystem,
-) -> list[MappingGroup]:
+) -> list[MappingGroupResponse]:
     """Returns mappings for specific mapping type and system combination."""
     try:
-        return mappings_service.get_mappings_by_systems(
-            mapping_type, source_system, target_system
-        )
+        return [
+            MappingGroupResponse.from_mapping_group(mapping_group)
+            for mapping_group in mappings_service.get_mappings_by_systems(
+                mapping_type, source_system, target_system
+            )
+        ]
     except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except PermissionError as e:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,6 +39,28 @@ def test_health_check() -> None:
     assert Ok() == Ok.model_validate(response.json())
 
 
+def test_openapi_mappings_response_schema_is_explicit() -> None:
+    """Ensure mappings responses expose a concrete schema in OpenAPI."""
+    schema = app.openapi()
+    response_schema = schema["paths"][
+        "/api/v1/project/mappings/{mapping_type}/{source_system}/{target_system}"
+    ]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+    mapping_group_schema = schema["components"]["schemas"]["MappingGroupResponse"]
+
+    assert response_schema["type"] == "array"
+    assert response_schema["items"] == {
+        "$ref": "#/components/schemas/MappingGroupResponse"
+    }
+
+    assert "official_name" in mapping_group_schema["properties"]
+    assert "mappings" in mapping_group_schema["properties"]
+    mappings_property = mapping_group_schema["properties"]["mappings"]
+    assert mappings_property["items"] == {
+        "$ref": "#/components/schemas/IdentifierMappingResponse"
+    }
+    assert mappings_property["type"] == "array"
+
+
 def test_shutdown_releases_project_lock() -> None:
     """Ensure lifespan teardown releases project locks."""
     lock = MagicMock()


### PR DESCRIPTION
Resolves #355 

Due to the `MappingGroup` model has different type internally vs. what is displayed from the API:
`MappingGroup` model:
```py
target_id: str
target_uuid: UUID | None = None
mapping_type: MappingType
target_system: DataSystem
source_system: DataSystem
mappings: list[AnyIdentifierMapping]
```
Serialized output:
```py
return {
    "official_name": self.target_id,
    "target_uuid": self.target_uuid,
    "mapping_type": self.mapping_type.value,
    "target_system": self.target_system.value,
    "source_system": self.source_system.value,
    "mappings": [
        {
            key: value
            for key, value in mapping.model_dump().items()
            if key not in excluded_fields
        }
        for mapping in self.mappings
    ],
}
```
the autogenerated type from `pnpm openapi-ts` cannot properly output the correct type. This PR added a proper response model for this.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
