### PR TITLE
ENH: add Sigrun and Sigrun Øst to sumo_assets.json

### DIFF
--- a/src/fmu_settings_api/interfaces/sumo_assets.json
+++ b/src/fmu_settings_api/interfaces/sumo_assets.json
@@ -163,5 +163,15 @@
         "name": "Eirin",
         "code": "033",
         "roleprefix": "EIRIN"
+    },
+    {
+        "name": "Sigrun",
+        "code": "034",
+        "roleprefix": "SIGRUN"
+    },
+    {
+        "name": "Sigrun Øst",
+        "code": "035",
+        "roleprefix": "SIGRUN-OST"
     }
 ]


### PR DESCRIPTION
Resolves #issue

This PR adds Sigrun and Sigrun Øst to the list of assets recognized by fmu-settings.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
