### PR TITLE
ENH: Use Drogon masterdata in SMDA endpoint for Drogon

### DIFF
--- a/src/fmu_settings_api/services/smda.py
+++ b/src/fmu_settings_api/services/smda.py
@@ -72,7 +72,13 @@ DROGON_STRATIGRAPHIC_UNITS: Final[list[StratigraphicUnit]] = [
 
 def _is_drogon_identifier(identifier: str) -> bool:
     """Returns whether an identifier refers to the Drogon field."""
-    return identifier.casefold() == DROGON_FIELD["identifier"].casefold()
+    search_identifier = identifier.casefold()
+    drogon_identifier = DROGON_FIELD["identifier"].casefold()
+
+    if search_identifier.endswith("*"):
+        return drogon_identifier.startswith(search_identifier.removesuffix("*"))
+
+    return search_identifier == drogon_identifier
 
 
 def _is_drogon_masterdata_request(smda_fields: list[SmdaSelectedField]) -> bool:

--- a/src/fmu_settings_api/services/smda.py
+++ b/src/fmu_settings_api/services/smda.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Sequence
+from typing import Any, Final
 
 import httpx
 from fmu.datamodels.common.masterdata import (
@@ -11,12 +12,18 @@ from fmu.datamodels.common.masterdata import (
     FieldItem,
     StratigraphicColumn,
 )
+from fmu.settings._drogon import (
+    MASTERDATA as DROGON_MASTERDATA,
+    RMS_ZONES as DROGON_RMS_ZONES,
+    STRATIGRAPHY_MAPPINGS as DROGON_STRATIGRAPHY_MAPPINGS,
+)
 
 from fmu_settings_api.interfaces import SmdaAPI
 from fmu_settings_api.logging import get_logger
 from fmu_settings_api.models.smda import (
     SmdaField,
     SmdaFieldSearchResult,
+    SmdaFieldUUID,
     SmdaMasterdataResult,
     SmdaSelectedField,
     SmdaStratigraphicUnitsResult,
@@ -24,6 +31,84 @@ from fmu_settings_api.models.smda import (
 )
 
 logger = get_logger(__name__)
+
+DROGON_SMDA_MASTERDATA: Final[dict[str, Any]] = DROGON_MASTERDATA["smda"]
+DROGON_FIELD: Final[dict[str, Any]] = DROGON_SMDA_MASTERDATA["field"][0]
+DROGON_STRAT_COLUMN: Final[dict[str, Any]] = DROGON_SMDA_MASTERDATA[
+    "stratigraphic_column"
+]
+DROGON_STRATIGRAPHY_BY_SOURCE_ID: Final[dict[str, dict[str, Any]]] = {
+    mapping["source_id"]: mapping
+    for mapping in DROGON_STRATIGRAPHY_MAPPINGS
+    if mapping["relation_type"] == "primary"
+}
+DROGON_STRATIGRAPHIC_UNITS: Final[list[StratigraphicUnit]] = [
+    StratigraphicUnit(
+        identifier=DROGON_STRATIGRAPHY_BY_SOURCE_ID[zone["name"]]["target_id"],
+        uuid=DROGON_STRATIGRAPHY_BY_SOURCE_ID[zone["name"]]["target_uuid"],
+        strat_unit_type="formation",
+        strat_unit_level=3,
+        top=DROGON_STRATIGRAPHY_BY_SOURCE_ID[zone["top_horizon_name"]]["target_id"],
+        top_uuid=DROGON_STRATIGRAPHY_BY_SOURCE_ID[zone["top_horizon_name"]][
+            "target_uuid"
+        ],
+        base=DROGON_STRATIGRAPHY_BY_SOURCE_ID[zone["base_horizon_name"]]["target_id"],
+        base_uuid=DROGON_STRATIGRAPHY_BY_SOURCE_ID[zone["base_horizon_name"]][
+            "target_uuid"
+        ],
+        top_age=0.0,
+        base_age=0.0,
+        strat_unit_parent=None,
+        strat_column_type="lithostratigraphy",
+        color_html=None,
+        color_r=None,
+        color_g=None,
+        color_b=None,
+    )
+    for zone in DROGON_RMS_ZONES
+    if zone["name"] in DROGON_STRATIGRAPHY_BY_SOURCE_ID
+]
+
+
+def _is_drogon_identifier(identifier: str) -> bool:
+    """Returns whether an identifier refers to the Drogon field."""
+    return identifier.casefold() == DROGON_FIELD["identifier"].casefold()
+
+
+def _is_drogon_masterdata_request(smda_fields: list[SmdaSelectedField]) -> bool:
+    """Returns whether all selected fields refer to the Drogon field."""
+    return bool(smda_fields) and all(
+        _is_drogon_identifier(field.identifier)
+        or str(field.uuid) == DROGON_FIELD["uuid"]
+        for field in smda_fields
+    )
+
+
+def _get_drogon_masterdata() -> SmdaMasterdataResult:
+    """Returns Drogon masterdata from fmu-settings."""
+    coordinate_system = CoordinateSystem.model_validate(
+        DROGON_SMDA_MASTERDATA["coordinate_system"]
+    )
+    return SmdaMasterdataResult(
+        field=[
+            FieldItem.model_validate(field) for field in DROGON_SMDA_MASTERDATA["field"]
+        ],
+        country=[
+            CountryItem.model_validate(country)
+            for country in DROGON_SMDA_MASTERDATA["country"]
+        ],
+        discovery=[
+            DiscoveryItem.model_validate(discovery)
+            for discovery in DROGON_SMDA_MASTERDATA["discovery"]
+        ],
+        stratigraphic_columns=[
+            StratigraphicColumn.model_validate(
+                DROGON_SMDA_MASTERDATA["stratigraphic_column"]
+            )
+        ],
+        field_coordinate_system=coordinate_system,
+        coordinate_systems=[coordinate_system],
+    )
 
 
 class SmdaService:
@@ -40,6 +125,22 @@ class SmdaService:
 
     async def search_field(self, field: SmdaField) -> SmdaFieldSearchResult:
         """Search for a field identifier in SMDA."""
+        if _is_drogon_identifier(field.identifier):
+            return SmdaFieldSearchResult(
+                hits=1,
+                pages=1,
+                results=[
+                    SmdaFieldUUID.model_validate(
+                        {
+                            **DROGON_FIELD,
+                            "country": DROGON_SMDA_MASTERDATA["country"][0][
+                                "identifier"
+                            ],
+                        }
+                    )
+                ],
+            )
+
         res = await self._smda.field(
             [field.identifier],
             columns=["country_identifier", "identifier", "uuid"],
@@ -61,6 +162,9 @@ class SmdaService:
         """Retrieve masterdata for fields to be confirmed in the GUI."""
         if not smda_fields:
             raise ValueError("At least one SMDA field must be provided")
+
+        if _is_drogon_masterdata_request(smda_fields):
+            return _get_drogon_masterdata()
 
         if smda_fields[0].uuid is not None:
             field_res = await self._smda.field(
@@ -166,6 +270,11 @@ class SmdaService:
         """Queries stratigraphic units for a stratigraphic column identifier."""
         if not strat_column_identifier:
             raise ValueError("A stratigraphic column identifier must be provided")
+
+        if strat_column_identifier == DROGON_STRAT_COLUMN["identifier"]:
+            return SmdaStratigraphicUnitsResult(
+                stratigraphic_units=DROGON_STRATIGRAPHIC_UNITS
+            )
 
         strat_unit_res = await self._smda.strat_units(
             strat_column_identifier,

--- a/tests/test_services/test_smda_service.py
+++ b/tests/test_services/test_smda_service.py
@@ -12,6 +12,7 @@ from fmu.datamodels.common.masterdata import (
     DiscoveryItem,
     StratigraphicColumn,
 )
+from fmu.settings._drogon import MASTERDATA as DROGON_MASTERDATA
 
 from fmu_settings_api.models.smda import SmdaField, SmdaSelectedField
 from fmu_settings_api.services.smda import SmdaService
@@ -357,6 +358,26 @@ async def test_get_stratigraphic_units_success() -> None:
     assert result.stratigraphic_units[0].base_uuid == base_uuid
 
 
+async def test_get_drogon_stratigraphic_units_uses_drogon_data() -> None:
+    """Tests that Drogon stratigraphic units do not call SMDA and use Drogon data."""
+    mock_smda = AsyncMock()
+    service = SmdaService(mock_smda)
+
+    result = await service.get_stratigraphic_units("DROGON_HAS_NO_STRATCOLUMN")
+
+    mock_smda.strat_units.assert_not_awaited()
+    mock_smda.surface.assert_not_awaited()
+    assert [unit.identifier for unit in result.stratigraphic_units] == [
+        "Valysar Fm.",
+        "Therys Fm.",
+        "Volon Fm.",
+    ]
+    assert result.stratigraphic_units[0].top == "VOLANTIS GP. Top"
+    assert result.stratigraphic_units[0].base == "Therys Fm. Top"
+    assert result.stratigraphic_units[0].strat_unit_type == "formation"
+    assert result.stratigraphic_units[0].top_age == 0.0
+
+
 async def test_get_stratigraphic_units_empty_identifier() -> None:
     """Tests ValueError raised when empty identifier provided."""
     mock_smda = AsyncMock()
@@ -522,7 +543,7 @@ async def test_search_field_adds_country_to_results() -> None:
             "results": [
                 {
                     "country_identifier": "Norway",
-                    "identifier": "DROGON",
+                    "identifier": "TROLL",
                     "uuid": field_uuid,
                 }
             ],
@@ -531,12 +552,26 @@ async def test_search_field_adds_country_to_results() -> None:
     mock_smda.field.return_value = field_resp
 
     service = SmdaService(mock_smda)
-    result = await service.search_field(SmdaField(identifier="DROGON"))
+    result = await service.search_field(SmdaField(identifier="TROLL"))
 
     mock_smda.field.assert_called_once_with(
-        ["DROGON"],
+        ["TROLL"],
         columns=["country_identifier", "identifier", "uuid"],
     )
+    assert result.results[0].country == "Norway"
+
+
+async def test_search_drogon_field_uses_drogon_data() -> None:
+    """Tests that Drogon field searches do not call SMDA and use Drogon data."""
+    mock_smda = AsyncMock()
+    service = SmdaService(mock_smda)
+
+    result = await service.search_field(SmdaField(identifier="Drogon"))
+
+    mock_smda.field.assert_not_called()
+    assert result.hits == 1
+    assert result.pages == 1
+    assert result.results[0].identifier == "DROGON"
     assert result.results[0].country == "Norway"
 
 
@@ -550,7 +585,7 @@ async def test_get_masterdata_uses_selected_field_uuid_for_lookup() -> None:
             "results": [
                 {
                     "country_identifier": "Norway",
-                    "identifier": "DROGON",
+                    "identifier": "TROLL",
                     "projected_coordinate_system": "ST_WGS84_UTM37N_P32637",
                     "uuid": selected_uuid,
                 },
@@ -596,7 +631,7 @@ async def test_get_masterdata_uses_selected_field_uuid_for_lookup() -> None:
 
     service = SmdaService(mock_smda)
     result = await service.get_masterdata(
-        [SmdaSelectedField(identifier="DROGON", uuid=selected_uuid)]
+        [SmdaSelectedField(identifier="TROLL", uuid=selected_uuid)]
     )
 
     mock_smda.field.assert_called_once_with(
@@ -610,3 +645,29 @@ async def test_get_masterdata_uses_selected_field_uuid_for_lookup() -> None:
     )
     assert len(result.field) == 1
     assert result.field[0].uuid == selected_uuid
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        SmdaSelectedField(identifier="Drogon"),
+        SmdaSelectedField(
+            identifier="any field but with Drogon uuid",
+            uuid=DROGON_MASTERDATA["smda"]["field"][0]["uuid"],
+        ),
+    ],
+)
+async def test_get_drogon_masterdata_uses_drogon_data(
+    field: SmdaSelectedField,
+) -> None:
+    """Tests that Drogon masterdata requests do not call SMDA and use Drogon data."""
+    mock_smda = AsyncMock()
+    service = SmdaService(mock_smda)
+
+    result = await service.get_masterdata([field])
+
+    mock_smda.field.assert_not_called()
+    assert result.field[0].identifier == "DROGON"
+    assert result.country[0].identifier == "Norway"
+    assert result.field_coordinate_system.identifier == "ST_WGS84_UTM37N_P32637"
+    assert result.stratigraphic_columns[0].identifier == "DROGON_HAS_NO_STRATCOLUMN"

--- a/tests/test_v1/test_smda.py
+++ b/tests/test_v1/test_smda.py
@@ -15,6 +15,7 @@ from fmu.datamodels.common.masterdata import (
     DiscoveryItem,
     StratigraphicColumn,
 )
+from fmu.settings._drogon import MASTERDATA as DROGON_MASTERDATA
 
 from fmu_settings_api.config import HttpHeader
 from fmu_settings_api.models.smda import (
@@ -184,7 +185,7 @@ async def test_post_field_succeeds_with_none(
     mock_SmdaAPI_post.return_value = mock_response
 
     response = client_with_smda_session.post(
-        f"{ROUTE}/field", json={"identifier": "DROGON"}
+        f"{ROUTE}/field", json={"identifier": "NONEXISTENT"}
     )
 
     assert response.status_code == status.HTTP_200_OK, response.json()
@@ -199,6 +200,31 @@ async def test_post_field_succeeds_with_none(
         pages=0,
         results=[],
     )
+
+
+async def test_post_field_drogon_uses_drogon_data(
+    client_with_smda_session: TestClient,
+    session_tmp_path: Path,
+    mock_SmdaAPI_post: AsyncMock,
+) -> None:
+    """Tests that Drogon field searches do not call SMDA and use Drogon data."""
+    response = client_with_smda_session.post(
+        f"{ROUTE}/field", json={"identifier": "Drogon"}
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "hits": 1,
+        "pages": 1,
+        "results": [
+            {
+                "identifier": "DROGON",
+                "uuid": "00000000-0000-0000-0000-000000000000",
+                "country": "Norway",
+            }
+        ],
+    }
+    mock_SmdaAPI_post.assert_not_awaited()
 
 
 async def test_post_field_with_no_identifier_raises(
@@ -295,7 +321,7 @@ async def test_post_masterdata_success(
             "results": [
                 {
                     "country_identifier": "Norway",
-                    "identifier": "DROGON",
+                    "identifier": "TROLL",
                     "projected_coordinate_system": "ST_WGS84_UTM37N_P32637",
                     "uuid": uuid4(),
                 }
@@ -348,7 +374,7 @@ async def test_post_masterdata_success(
             StratigraphicColumn(identifier="LITHO_VISERION", uuid=uuid4()),
         ]
         response = client_with_smda_session.post(
-            f"{ROUTE}/masterdata", json=[{"identifier": "DROGON"}]
+            f"{ROUTE}/masterdata", json=[{"identifier": "TROLL"}]
         )
 
     assert response.status_code == status.HTTP_200_OK, response.json()
@@ -358,14 +384,14 @@ async def test_post_masterdata_success(
     )
     response_data = response.json()
     assert len(response_data["field"]) == 1
-    assert response_data["field"][0]["identifier"] == "DROGON"
+    assert response_data["field"][0]["identifier"] == "TROLL"
     assert (
         response_data["field_coordinate_system"]["identifier"]
         == "ST_WGS84_UTM37N_P32637"
     )
 
     mock_smda_instance.field.assert_called_once_with(
-        ["DROGON"],
+        ["TROLL"],
         columns=[
             "country_identifier",
             "identifier",
@@ -390,7 +416,7 @@ async def test_post_masterdata_uses_selected_field_uuid_for_lookup(
             "results": [
                 {
                     "country_identifier": "Norway",
-                    "identifier": "DROGON",
+                    "identifier": "TROLL",
                     "projected_coordinate_system": "ST_WGS84_UTM37N_P32637",
                     "uuid": selected_uuid,
                 },
@@ -438,7 +464,7 @@ async def test_post_masterdata_uses_selected_field_uuid_for_lookup(
         mock_get_strat_column_areas.return_value = []
         response = client_with_smda_session.post(
             f"{ROUTE}/masterdata",
-            json=[{"identifier": "DROGON", "uuid": str(selected_uuid)}],
+            json=[{"identifier": "TROLL", "uuid": str(selected_uuid)}],
         )
 
     assert response.status_code == status.HTTP_200_OK, response.json()
@@ -458,6 +484,36 @@ async def test_post_masterdata_uses_selected_field_uuid_for_lookup(
     )
 
 
+@pytest.mark.parametrize(
+    "field",
+    [
+        {"identifier": "Drogon"},
+        {
+            "identifier": "any field but with Drogon uuid",
+            "uuid": DROGON_MASTERDATA["smda"]["field"][0]["uuid"],
+        },
+    ],
+)
+async def test_post_masterdata_drogon_uses_drogon_data(
+    client_with_smda_session: TestClient,
+    session_tmp_path: Path,
+    mock_SmdaAPI_post: AsyncMock,
+    field: dict[str, str],
+) -> None:
+    """Tests that Drogon masterdata requests do not call SMDA and use Drogon data."""
+    response = client_with_smda_session.post(f"{ROUTE}/masterdata", json=[field])
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    response_data = response.json()
+    assert response_data["field"] == DROGON_MASTERDATA["smda"]["field"]
+    assert response_data["country"] == DROGON_MASTERDATA["smda"]["country"]
+    assert (
+        response_data["field_coordinate_system"]
+        == DROGON_MASTERDATA["smda"]["coordinate_system"]
+    )
+    mock_SmdaAPI_post.assert_not_awaited()
+
+
 async def test_post_masterdata_missing_coordinate_system(
     client_with_smda_session: TestClient,
     session_tmp_path: Path,
@@ -472,7 +528,7 @@ async def test_post_masterdata_missing_coordinate_system(
             "results": [
                 {
                     "country_identifier": "Norway",
-                    "identifier": "DROGON",
+                    "identifier": "TROLL",
                     "projected_coordinate_system": "UNKNOWN_CRS",
                     "uuid": uuid4(),
                 }
@@ -515,7 +571,7 @@ async def test_post_masterdata_missing_coordinate_system(
         mock_get_discoveries.return_value = []
         mock_get_strat_column_areas.return_value = []
         response = client_with_smda_session.post(
-            f"{ROUTE}/masterdata", json=[{"identifier": "DROGON"}]
+            f"{ROUTE}/masterdata", json=[{"identifier": "TROLL"}]
         )
 
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
@@ -524,8 +580,7 @@ async def test_post_masterdata_missing_coordinate_system(
         == HttpHeader.UPSTREAM_SOURCE_SMDA
     )
     expected_msg = (
-        "Coordinate system 'UNKNOWN_CRS' referenced by field 'DROGON' "
-        "not found in SMDA."
+        "Coordinate system 'UNKNOWN_CRS' referenced by field 'TROLL' not found in SMDA."
     )
     assert expected_msg in response.json()["detail"]
 
@@ -547,7 +602,7 @@ async def test_post_masterdata_malformed_response(
         mock_smda_class.return_value = mock_smda_instance
 
         response = client_with_smda_session.post(
-            f"{ROUTE}/masterdata", json=[{"identifier": "DROGON"}]
+            f"{ROUTE}/masterdata", json=[{"identifier": "TROLL"}]
         )
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, (
@@ -919,7 +974,7 @@ async def test_post_masterdata_request_fails(
 
     response = client_with_smda_session.post(
         f"{ROUTE}/masterdata",
-        json=[{"identifier": "DROGON"}],
+        json=[{"identifier": "TROLL"}],
     )
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.json()
@@ -942,7 +997,7 @@ async def test_post_masterdata_request_timeout(
 
         response = client_with_smda_session.post(
             f"{ROUTE}/masterdata",
-            json=[{"identifier": "DROGON"}],
+            json=[{"identifier": "TROLL"}],
         )
 
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE, response.json()
@@ -1001,6 +1056,26 @@ async def test_post_strat_units_success(
     assert len(response_data["stratigraphic_units"]) == 1
     assert response_data["stratigraphic_units"][0]["identifier"] == "VIKING GP."
     assert response_data["stratigraphic_units"][0]["strat_unit_type"] == "group"
+
+
+async def test_post_strat_units_drogon_uses_drogon_data(
+    client_with_smda_session: TestClient,
+    session_tmp_path: Path,
+    mock_SmdaAPI_post: AsyncMock,
+) -> None:
+    """Tests that Drogon stratigraphic units do not call SMDA and use Drogon data."""
+    response = client_with_smda_session.post(
+        f"{ROUTE}/strat_units",
+        json={"strat_column_identifier": "DROGON_HAS_NO_STRATCOLUMN"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert [unit["identifier"] for unit in response.json()["stratigraphic_units"]] == [
+        "Valysar Fm.",
+        "Therys Fm.",
+        "Volon Fm.",
+    ]
+    mock_SmdaAPI_post.assert_not_awaited()
 
 
 async def test_post_strat_units_empty_results(

--- a/tests/test_v1/test_smda.py
+++ b/tests/test_v1/test_smda.py
@@ -227,6 +227,31 @@ async def test_post_field_drogon_uses_drogon_data(
     mock_SmdaAPI_post.assert_not_awaited()
 
 
+async def test_post_field_drogon_wildcard_uses_drogon_data(
+    client_with_smda_session: TestClient,
+    session_tmp_path: Path,
+    mock_SmdaAPI_post: AsyncMock,
+) -> None:
+    """Tests that Drogon wildcard searches use Drogon data."""
+    response = client_with_smda_session.post(
+        f"{ROUTE}/field", json={"identifier": "DRO*"}
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json() == {
+        "hits": 1,
+        "pages": 1,
+        "results": [
+            {
+                "identifier": "DROGON",
+                "uuid": "00000000-0000-0000-0000-000000000000",
+                "country": "Norway",
+            }
+        ],
+    }
+    mock_SmdaAPI_post.assert_not_awaited()
+
+
 async def test_post_field_with_no_identifier_raises(
     client_with_smda_session: TestClient,
     session_tmp_path: Path,


### PR DESCRIPTION
Resolves #381 

- Serve Drogon field search and masterdata directly from `fmu.settings._drogon` instead of querying SMDA.
- Support Drogon masterdata lookup by field name or UUID.
- Serve Drogon stratigraphic units locally from the Drogon mappings.

<img width="994" height="814" alt="image" src="https://github.com/user-attachments/assets/7a7a8841-8384-4b1b-b213-1acd187908b1" />
<img width="988" height="657" alt="image" src="https://github.com/user-attachments/assets/c283dc09-f073-48b3-a805-4b89ca83d8e0" />
<img width="912" height="656" alt="image" src="https://github.com/user-attachments/assets/e7bf1250-659b-4fea-8cbd-73a7ae595d40" />
 There's an issue that we can't map TopVolon to Volon Fm. Top because it has the same uuid as Therys Fm. Top in Drogon data. Created this issue to fix that equinor/fmu-settings/issues/261

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
