### PR TITLE
ENH: Combine SMDA search results and Drogon in wildcard search

### DIFF
--- a/src/fmu_settings_api/services/smda.py
+++ b/src/fmu_settings_api/services/smda.py
@@ -72,13 +72,29 @@ DROGON_STRATIGRAPHIC_UNITS: Final[list[StratigraphicUnit]] = [
 
 def _is_drogon_identifier(identifier: str) -> bool:
     """Returns whether an identifier refers to the Drogon field."""
-    search_identifier = identifier.casefold()
-    drogon_identifier = DROGON_FIELD["identifier"].casefold()
+    return identifier.casefold() == DROGON_FIELD["identifier"].casefold()
 
-    if search_identifier.endswith("*"):
-        return drogon_identifier.startswith(search_identifier.removesuffix("*"))
 
-    return search_identifier == drogon_identifier
+def _field_search_includes_drogon(identifier: str) -> bool:
+    """Returns whether a field search pattern would include the Drogon field.
+
+    Examples: ``DRO*`` and ``Drogon`` include Drogon, ``OSEBERG*`` does not.
+    """
+    if not identifier.endswith("*"):
+        return _is_drogon_identifier(identifier)
+
+    search_prefix = identifier.removesuffix("*").casefold()
+    return DROGON_FIELD["identifier"].casefold().startswith(search_prefix)
+
+
+def _get_drogon_field_uuid() -> SmdaFieldUUID:
+    """Returns the Drogon field search result item."""
+    return SmdaFieldUUID.model_validate(
+        {
+            **DROGON_FIELD,
+            "country": DROGON_SMDA_MASTERDATA["country"][0]["identifier"],
+        }
+    )
 
 
 def _is_drogon_masterdata_request(smda_fields: list[SmdaSelectedField]) -> bool:
@@ -135,16 +151,7 @@ class SmdaService:
             return SmdaFieldSearchResult(
                 hits=1,
                 pages=1,
-                results=[
-                    SmdaFieldUUID.model_validate(
-                        {
-                            **DROGON_FIELD,
-                            "country": DROGON_SMDA_MASTERDATA["country"][0][
-                                "identifier"
-                            ],
-                        }
-                    )
-                ],
+                results=[_get_drogon_field_uuid()],
             )
 
         res = await self._smda.field(
@@ -160,6 +167,11 @@ class SmdaService:
             }
             for result in data["results"]
         ]
+        if _field_search_includes_drogon(field.identifier):
+            drogon_field = _get_drogon_field_uuid()
+            data["hits"] += 1
+            data["results"].append(drogon_field.model_dump(mode="json"))
+
         return SmdaFieldSearchResult(**data)
 
     async def get_masterdata(

--- a/tests/test_v1/test_smda.py
+++ b/tests/test_v1/test_smda.py
@@ -227,29 +227,61 @@ async def test_post_field_drogon_uses_drogon_data(
     mock_SmdaAPI_post.assert_not_awaited()
 
 
-async def test_post_field_drogon_wildcard_uses_drogon_data(
+@pytest.mark.parametrize(
+    ("identifier", "smda_identifier"),
+    [
+        ("D*", "DRAKE"),
+        ("DRO*", "DROSHKY"),
+    ],
+)
+async def test_post_field_drogon_wildcard_adds_drogon_to_smda_results(
     client_with_smda_session: TestClient,
     session_tmp_path: Path,
     mock_SmdaAPI_post: AsyncMock,
+    identifier: str,
+    smda_identifier: str,
 ) -> None:
-    """Tests that Drogon wildcard searches use Drogon data."""
+    """Tests that Drogon wildcard searches keep SMDA results."""
+    uuid = uuid4()
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": {
+            "hits": 1,
+            "pages": 1,
+            "results": [
+                {
+                    "country_identifier": "Norway",
+                    "identifier": smda_identifier,
+                    "uuid": str(uuid),
+                }
+            ],
+        }
+    }
+    mock_SmdaAPI_post.return_value = mock_response
+
     response = client_with_smda_session.post(
-        f"{ROUTE}/field", json={"identifier": "DRO*"}
+        f"{ROUTE}/field", json={"identifier": identifier}
     )
 
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json() == {
-        "hits": 1,
+        "hits": 2,
         "pages": 1,
         "results": [
+            {
+                "identifier": smda_identifier,
+                "uuid": str(uuid),
+                "country": "Norway",
+            },
             {
                 "identifier": "DROGON",
                 "uuid": "00000000-0000-0000-0000-000000000000",
                 "country": "Norway",
-            }
+            },
         ],
     }
-    mock_SmdaAPI_post.assert_not_awaited()
+    mock_SmdaAPI_post.assert_awaited_once()
 
 
 async def test_post_field_with_no_identifier_raises(


### PR DESCRIPTION
Resolves #385 

Now Drogon wildcard search combines the result from SMDA field search and Drogon data, instead of only showing Drogon.
<img width="438" height="754" alt="2026-06-02_5-22-04 PM" src="https://github.com/user-attachments/assets/423739f2-08ea-44e0-a564-c549e5faf989" />


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
