### PR TITLE
ENH: Switch private imports symbols to public imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version"]
 dependencies = [
     "fastapi",
     "fmu-datamodels>=0.21.4",  # no equivalent relation, no fmu data system
-    "fmu-settings>=0.30.0",  # current InternalMappings schema
+    "fmu-settings>=0.32.1",  # public imports for global config
     "httpx",
     "packaging",
     "pydantic",

--- a/src/fmu_settings_api/services/project.py
+++ b/src/fmu_settings_api/services/project.py
@@ -4,8 +4,7 @@ from pathlib import Path
 
 from fmu.datamodels.common import Access, Smda
 from fmu.datamodels.fmu_results.fields import Model
-from fmu.settings import ProjectFMUDirectory
-from fmu.settings._global_config import find_global_config
+from fmu.settings import ProjectFMUDirectory, find_global_config
 from fmu.settings.models.project_config import (
     RmsCoordinateSystem,
     RmsHorizon,

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -19,9 +19,9 @@ from fmu.settings import (
     InternalStratigraphyMappings,
     InternalWellboreMappings,
     InvalidFMUProjectPathError,
+    InvalidGlobalConfigurationError,
     ProjectFMUDirectory,
 )
-from fmu.settings._global_config import InvalidGlobalConfigurationError
 from fmu.settings.models.change_info import ChangeInfo
 from fmu.settings.models.diff import ResourceDiff
 from fmu.settings.models.log import Log

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -22,11 +22,11 @@ from fmu.settings import (
     InternalStratigraphyIdentifierMapping,
     InternalStratigraphyMappings,
     InternalWellboreMappings,
+    InvalidGlobalConfigurationError,
     ProjectFMUDirectory,
     UserFMUDirectory,
     init_fmu_directory,
 )
-from fmu.settings._global_config import InvalidGlobalConfigurationError
 from fmu.settings.models._enums import ChangeType
 from fmu.settings.models.change_info import ChangeInfo
 from pydantic import ValidationError

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-19T19:50:30.088253Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -348,7 +348,7 @@ wheels = [
 
 [[package]]
 name = "fmu-settings"
-version = "0.31.0"
+version = "0.32.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -358,9 +358,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/70/9a5910411b8ae0cb55fb9cfc4f51e05b874c7b26cd9ac6e86a50d91bc272/fmu_settings-0.31.0.tar.gz", hash = "sha256:bf211c865b6738c697c6f00cc285cd504bd6ecdd2b5ce84f2bd44afd85ace9bc", size = 773182, upload-time = "2026-05-13T06:37:47.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/84/db33f98a4708ad3bd4598234bd22513a3cabb9f4a49af7b9bf19b7dddf57/fmu_settings-0.32.1.tar.gz", hash = "sha256:0c052eed3ba2391ec37085993fea48a3ca1b67250e841ae64a4b26a24d398614", size = 777755, upload-time = "2026-06-02T11:51:02.623Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/d9/3e274b64d02101dda2e67be9f212ac10ef4ef4f392e501325d3b919a166d/fmu_settings-0.31.0-py3-none-any.whl", hash = "sha256:03c809223e24c2aec471c47b7b4866379258d3449799d21be73c27d19c732f11", size = 60259, upload-time = "2026-05-13T06:37:45.851Z" },
+    { url = "https://files.pythonhosted.org/packages/45/d5/337712b17a0726e1fb24b40fec3b908dce4c4fa670d2fa1fdf342cc2aa45/fmu_settings-0.32.1-py3-none-any.whl", hash = "sha256:60dc8955b5ef1a3a5708f1d693879dcfe23a686b818ce9507135f443c3458501", size = 61091, upload-time = "2026-06-02T11:51:01.079Z" },
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ dev = [
 requires-dist = [
     { name = "fastapi" },
     { name = "fmu-datamodels", specifier = ">=0.21.4" },
-    { name = "fmu-settings", specifier = ">=0.30.0" },
+    { name = "fmu-settings", specifier = ">=0.32.1" },
     { name = "fmu-settings-cli", marker = "extra == 'dev'" },
     { name = "httpx" },
     { name = "mypy", marker = "extra == 'dev'" },


### PR DESCRIPTION
Replace private _global_config imports with public root imports from fmu.settings:
   - find_global_config in project service
   - InvalidGlobalConfigurationError in project route and matching tests

Resolves #376

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
