### PR TITLE
ENH: Simplify match endpoint to generic ranked name matching

### DIFF
--- a/src/fmu_settings_api/models/match.py
+++ b/src/fmu_settings_api/models/match.py
@@ -1,27 +1,58 @@
-"""Models for matching."""
+"""Models for matching names."""
 
+import re
 from typing import Literal
 
-from fmu.datamodels.common.masterdata import CoordinateSystem
-from fmu.settings.models.project_config import RmsCoordinateSystem, RmsStratigraphicZone
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from fmu_settings_api.models.common import BaseResponseModel
 
-from .smda import StratigraphicUnit
+
+class MatchReplacementRule(BaseResponseModel):
+    """A normalized token sequence replacement to apply before matching."""
+
+    original: str
+    """The normalized token sequence to replace."""
+
+    replacement: str
+    """The replacement token sequence."""
+
+    @field_validator("original")
+    @classmethod
+    def original_must_not_normalize_to_empty(cls, value: str) -> str:
+        """Validate that original contains something replaceable."""
+        if not re.sub(r"[_.\-/]", " ", value).strip():
+            msg = (
+                "Original must include text after normalization. Empty values and "
+                'separators such as "_", ".", "-", and "/" cannot be replaced. '
+                "Those separators are normalized automatically. Replacement rules "
+                'are only needed for text values, for example "Fm" -> "Formation".'
+            )
+            raise ValueError(msg)
+        return value
 
 
-class RmsStratigraphyMatch(BaseResponseModel):
-    """A matched pair of RMS zone and SMDA stratigraphic unit."""
+class MatchRequest(BaseResponseModel):
+    """A request to match source names against target names."""
 
-    rms_zone: RmsStratigraphicZone
-    """The RMS stratigraphic zone."""
+    sources: list[str]
+    """Names to match from."""
 
-    smda_unit: StratigraphicUnit
-    """The matched SMDA stratigraphic unit."""
+    targets: list[str]
+    """Names to match against."""
+
+    replacements: list[MatchReplacementRule] = Field(default_factory=list)
+    """Optional normalized token sequence replacements to apply before matching."""
+
+
+class MatchCandidate(BaseResponseModel):
+    """A target candidate for a source name."""
+
+    target: str
+    """The candidate target name."""
 
     score: float = Field(ge=0, le=100)
-    """Similarity score for the zone/unit names (0-100)."""
+    """Similarity score for the normalized source and target names (0-100)."""
 
     confidence: Literal["high", "medium", "low"]
     """Confidence level based on score.
@@ -30,20 +61,11 @@ class RmsStratigraphyMatch(BaseResponseModel):
     """
 
 
-class RmsCoordinateSystemMatch(BaseResponseModel):
-    """A matched coordinate system."""
+class MatchResult(BaseResponseModel):
+    """The target candidates for a source name."""
 
-    rms_crs_sys: RmsCoordinateSystem
-    """The source coordinate system to be matched."""
+    source: str
+    """The source name."""
 
-    smda_crs_sys: CoordinateSystem
-    """The matched target coordinate system."""
-
-    score: float = Field(ge=0, le=100)
-    """Similarity score for the coordinate systems (0-100)."""
-
-    confidence: Literal["high", "medium", "low"]
-    """Confidence level based on score.
-
-    'high' (>80), 'medium' (50-80), 'low' (<50).
-    """
+    matches: list[MatchCandidate]
+    """The best target candidates for the source name."""

--- a/src/fmu_settings_api/services/match.py
+++ b/src/fmu_settings_api/services/match.py
@@ -1,261 +1,144 @@
-"""Service for matching two different entities."""
+"""Service for matching names."""
 
 import re
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
-from fmu.datamodels.common.masterdata import CoordinateSystem
-from fmu.settings.models.project_config import RmsCoordinateSystem, RmsStratigraphicZone
 from rapidfuzz import fuzz
 
 from fmu_settings_api.models.match import (
-    RmsCoordinateSystemMatch,
-    RmsStratigraphyMatch,
+    MatchCandidate,
+    MatchReplacementRule,
+    MatchResult,
 )
-from fmu_settings_api.models.smda import StratigraphicUnit
-
-if TYPE_CHECKING:
-    from fmu_settings_api.services.smda import SmdaService
-    from fmu_settings_api.session import ProjectSession
 
 HIGH_CONFIDENCE_THRESHOLD = 80
 MEDIUM_CONFIDENCE_THRESHOLD = 50
+TOP_MATCHES_PER_SOURCE = 3
 
 
 class MatchService:
-    """Service for matching two different entities."""
+    """Service for matching names."""
 
-    async def match_stratigraphy_from_config_to_smda(
+    def match_names(
         self,
-        project_session: "ProjectSession",
-        smda_service: "SmdaService",
-    ) -> list[RmsStratigraphyMatch]:
-        """Match RMS zones from project config to SMDA stratigraphic units.
+        sources: list[str],
+        targets: list[str],
+        replacements: list[MatchReplacementRule] | None = None,
+    ) -> list[MatchResult]:
+        """Match source names to target names using strict name similarity.
 
-        This is a convenience method that:
-        1. Fetches RMS zones from project config (rms.zones)
-        2. Fetches stratigraphic column identifier from masterdata
-        3. Queries SMDA for stratigraphic units
-        4. Performs the matching using match_stratigraphy()
+        For each source name, finds the three highest-scoring target names
+        using strict ratio matching after normalization.
 
         Args:
-            project_session: Session service with project configuration access
-            smda_service: SMDA service for querying stratigraphic units
+            sources: Names to match from.
+            targets: Names to match against.
+            replacements: Optional string replacements to apply before matching.
 
         Returns:
-            List of RmsStratigraphyMatch objects
-
-        Raises:
-            ValueError: If config values are missing or invalid
-            httpx.HTTPStatusError: If SMDA API request fails
-            KeyError: If SMDA response is malformed
-            TimeoutError: If SMDA API request times out
-        """
-        rms_zones_config = project_session.project_fmu_directory.get_config_value(
-            "rms.zones", None
-        )
-
-        if not rms_zones_config:
-            raise ValueError(
-                "No RMS zones found in project config. "
-                "Please configure rms.zones in the project config."
-            )
-
-        rms_zones = [RmsStratigraphicZone.model_validate(z) for z in rms_zones_config]
-
-        strat_column_identifier = (
-            project_session.project_fmu_directory.get_config_value(
-                "masterdata.smda.stratigraphic_column.identifier", None
-            )
-        )
-
-        if not strat_column_identifier:
-            raise ValueError(
-                "No stratigraphic column identifier found in project masterdata. "
-                "Please configure masterdata.smda.stratigraphic_column.identifier "
-                "in the project config."
-            )
-
-        smda_units_result = await smda_service.get_stratigraphic_units(
-            strat_column_identifier
-        )
-
-        return self.match_stratigraphy(rms_zones, smda_units_result.stratigraphic_units)
-
-    def match_coordinate_system_from_config_to_smda(
-        self,
-        project_session: "ProjectSession",
-    ) -> RmsCoordinateSystemMatch:
-        """Match RMS coordinate system to SMDA coordinate system from project config.
-
-        This is a convenience method that:
-        1. Fetches RMS coordinate system from project config (rms.coordinate_system)
-        2. Fetches SMDA coordinate system from masterdata
-        3. Performs the matching using match_coordinate_system()
-
-        Args:
-            project_session: Session service with project configuration access
-
-        Returns:
-            RmsCoordinateSystemMatch object
-
-        Raises:
-            ValueError: If config values are missing or invalid
-        """
-        rms_crs_config = project_session.project_fmu_directory.get_config_value(
-            "rms.coordinate_system", None
-        )
-
-        if not rms_crs_config:
-            raise ValueError(
-                "No RMS coordinate system found in project config. "
-                "Please configure rms.coordinate_system in the project config."
-            )
-
-        rms_crs = RmsCoordinateSystem.model_validate(rms_crs_config)
-
-        smda_crs_config = project_session.project_fmu_directory.get_config_value(
-            "masterdata.smda.coordinate_system", None
-        )
-
-        if not smda_crs_config:
-            raise ValueError(
-                "No SMDA coordinate system found in project masterdata. "
-                "Please configure masterdata.smda.coordinate_system "
-                "in the project config."
-            )
-
-        smda_crs = CoordinateSystem.model_validate(smda_crs_config)
-
-        return self.match_coordinate_system(rms_crs, smda_crs)
-
-    def match_stratigraphy(
-        self,
-        rms_zones: list[RmsStratigraphicZone],
-        smda_units: list[StratigraphicUnit],
-    ) -> list[RmsStratigraphyMatch]:
-        """Match RMS zones to SMDA stratigraphic units using greedy algorithm.
-
-        For each zone, finds the best-matching unit based on name similarity
-        using token-sort ratio for flexible matching.
-
-        Args:
-            rms_zones: List of RMS stratigraphic zones to match
-            smda_units: List of SMDA stratigraphic units to match against
-
-        Returns:
-            List of RmsStratigraphyMatch objects in the original zone order.
-            Each zone is matched to its highest-scoring unit.
+            Match results in the original source order. Each source result
+            includes up to three targets, ordered from highest to lowest score.
         """
         matches = []
 
-        for zone in rms_zones:
-            best_unit = None
-            best_score = -1.0
-
-            for unit in smda_units:
-                score = self._calculate_name_score(zone.name, unit.identifier)
-
-                if score > best_score:
-                    best_score = score
-                    best_unit = unit
-
-            if best_unit is not None:
-                confidence = self._determine_confidence(best_score)
-                matches.append(
-                    RmsStratigraphyMatch(
-                        rms_zone=zone,
-                        smda_unit=best_unit,
-                        score=best_score,
-                        confidence=confidence,
+        for source in sources:
+            target_scores = sorted(
+                (
+                    (
+                        target,
+                        self._calculate_name_score(source, target, replacements),
                     )
+                    for target in targets
+                ),
+                key=lambda target_score: target_score[1],
+                reverse=True,
+            )
+
+            matches.append(
+                MatchResult(
+                    source=source,
+                    matches=[
+                        MatchCandidate(
+                            target=target,
+                            score=score,
+                            confidence=self._determine_confidence(score),
+                        )
+                        for target, score in target_scores[:TOP_MATCHES_PER_SOURCE]
+                    ],
                 )
+            )
 
         return matches
 
-    def match_coordinate_system(
+    def _calculate_name_score(
         self,
-        rms_crs_sys: RmsCoordinateSystem,
-        smda_crs_sys: CoordinateSystem,
-    ) -> RmsCoordinateSystemMatch:
-        """Match RMS coordinate system to SMDA coordinate system.
-
-        Args:
-            rms_crs_sys: The RMS coordinate system to be matched
-            smda_crs_sys: The SMDA coordinate system to match against
-
-        Returns:
-            The CoordinateSystemMatch object with score and confidence.
-        """
-        score = self._calculate_name_score_strict(
-            rms_crs_sys.name, smda_crs_sys.identifier
-        )
-
-        confidence = self._determine_confidence(score)
-        return RmsCoordinateSystemMatch(
-            rms_crs_sys=rms_crs_sys,
-            smda_crs_sys=smda_crs_sys,
-            score=score,
-            confidence=confidence,
-        )
-
-    def _normalize_name(self, name: str) -> list[str]:
-        """Normalize a name for comparison.
-
-        Converts to lowercase, replaces underscores and dots with spaces,
-        and returns list of tokens.
-
-        Example:
-            "Eiriksson Fm 2.1" -> ["eiriksson", "fm", "2", "1"]
-
-        Args:
-            name: The name to normalize
-
-        Returns:
-            List of normalized tokens
-        """
-        return re.sub(r"[_.]", " ", name.lower()).split()
-
-    def _calculate_name_score_strict(self, name1: str, name2: str) -> float:
+        name1: str,
+        name2: str,
+        replacements: list[MatchReplacementRule] | None = None,
+    ) -> float:
         """Calculate strict similarity score for two names.
 
-        Uses simple ratio matching for exact word order.
-
         Args:
-            name1: First name to compare
-            name2: Second name to compare
+            name1: First name to compare.
+            name2: Second name to compare.
+            replacements: Optional string replacements to apply.
 
         Returns:
-            Similarity score from 0 to 100
+            Similarity score from 0 to 100.
         """
-        tokens1 = self._normalize_name(name1)
-        tokens2 = self._normalize_name(name2)
-        return fuzz.ratio(" ".join(tokens1), " ".join(tokens2))
+        return fuzz.ratio(
+            self._normalize_name(name1, replacements),
+            self._normalize_name(name2, replacements),
+        )
 
-    def _calculate_name_score(self, name1: str, name2: str) -> float:
-        """Calculate similarity score for two names.
+    def _normalize_name(
+        self,
+        name: str,
+        replacements: list[MatchReplacementRule] | None = None,
+    ) -> str:
+        """Normalize a name for comparison.
 
-        Uses token-sort ratio for flexible matching that allows different
-        word ordering (e.g., "VIKING GP" matches "GP VIKING").
+        Converts to lowercase, replaces underscores, dots, dashes, and slashes
+        with spaces, collapses whitespace, and applies replacement rules to
+        whole normalized token sequences only.
+
+        Example:
+            With replacement {"original": "fm", "replacement": "formation"}:
+            "Eiriksson_Fm-2/1.1" -> "eiriksson formation 2 1 1"
+            With replacement {"original": "top", "replacement": ""}:
+            "Stop Viking" -> "stop viking", because "top" is not a whole token.
 
         Args:
-            name1: First name to compare
-            name2: Second name to compare
+            name: The name to normalize.
+            replacements: Optional string replacements to apply.
 
         Returns:
-            Similarity score from 0 to 100
+            Normalized name.
         """
-        tokens1 = self._normalize_name(name1)
-        tokens2 = self._normalize_name(name2)
-        return fuzz.token_sort_ratio(" ".join(tokens1), " ".join(tokens2))
+        normalized_name = " ".join(re.sub(r"[_.\-/]", " ", name.lower()).split())
+
+        for replacement in replacements or []:
+            original = " ".join(
+                re.sub(r"[_.\-/]", " ", replacement.original.lower()).split()
+            )
+            replacement_value = " ".join(
+                re.sub(r"[_.\-/]", " ", replacement.replacement.lower()).split()
+            )
+            pattern = rf"(?<!\S){re.escape(original)}(?!\S)"
+
+            normalized_name = re.sub(pattern, replacement_value, normalized_name)
+            normalized_name = " ".join(normalized_name.split())
+
+        return normalized_name
 
     def _determine_confidence(self, score: float) -> Literal["high", "medium", "low"]:
         """Determine confidence level based on total score.
 
         Args:
-            score: Total similarity score (0-100)
+            score: Total similarity score (0-100).
 
         Returns:
-            Confidence level: 'high' (>80), 'medium' (50-80), 'low' (<50)
+            Confidence level: 'high' (>80), 'medium' (50-80), 'low' (<50).
         """
         if score > HIGH_CONFIDENCE_THRESHOLD:
             return "high"

--- a/src/fmu_settings_api/v1/routes/match.py
+++ b/src/fmu_settings_api/v1/routes/match.py
@@ -3,74 +3,19 @@
 from textwrap import dedent
 from typing import Final
 
-import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
-from fmu_settings_api.config import HttpHeader
-from fmu_settings_api.deps import ProjectSmdaServiceDep
 from fmu_settings_api.deps.match import MatchServiceDep
-from fmu_settings_api.deps.session import ProjectSessionDep
-from fmu_settings_api.models.match import (
-    RmsCoordinateSystemMatch,
-    RmsStratigraphyMatch,
-)
-from fmu_settings_api.v1.responses import (
-    GetSessionResponses,
-    Responses,
-    inline_add_response,
-)
+from fmu_settings_api.models.match import MatchRequest, MatchResult
+from fmu_settings_api.v1.responses import Responses, inline_add_response
 
 MatchResponses: Final[Responses] = {
     **inline_add_response(
-        400,
-        dedent(
-            """
-            Required configuration is missing from the project config,
-            or invalid parameters are provided.
-            """
-        ),
-        [
-            {"detail": "RMS zones not found in project configuration"},
-            {"detail": "RMS coordinate system not found in project configuration"},
-            {"detail": "SMDA masterdata not found in project configuration"},
-            {"detail": "Stratigraphic column identifier not found in masterdata"},
-        ],
-    ),
-    **inline_add_response(
         422,
-        dedent(
-            """
-            SMDA returns valid data but no results are found,
-            or configuration exists but contains no matchable data.
-            """
-        ),
+        "The request body is missing required match input or contains invalid data.",
         [
-            {"detail": "No stratigraphic units found for column: {identifier}"},
-            {"detail": "No RMS zones available for matching"},
-        ],
-    ),
-    **inline_add_response(
-        500,
-        dedent(
-            """
-            SMDA returns a malformed response that doesn't match
-            the expected structure.
-            """
-        ),
-        [
-            {"detail": "Malformed response from SMDA: {error_details}"},
-        ],
-    ),
-    **inline_add_response(
-        503,
-        dedent(
-            """
-            An API call to SMDA times out or the service is unavailable.
-            """
-        ),
-        [
-            {"detail": "SMDA API request timed out. Please try again."},
-            {"detail": "SMDA error requesting {url}"},
+            {"detail": "Field required"},
+            {"detail": "Input should be a valid list"},
         ],
     ),
 }
@@ -78,132 +23,43 @@ MatchResponses: Final[Responses] = {
 router = APIRouter(prefix="/match", tags=["match"])
 
 
-@router.get(
-    "/stratigraphy",
-    response_model=list[RmsStratigraphyMatch],
-    summary="Match RMS zones to SMDA stratigraphic units",
+@router.post(
+    "",
+    response_model=list[MatchResult],
+    summary="Match source names to target names",
     description=dedent(
         """
-        Match RMS stratigraphic zones to SMDA stratigraphic units using a
-        greedy matching algorithm based on name similarity.
+        Match source names to target names using strict name similarity.
 
-        This endpoint automatically fetches:
-        - RMS zones from the project configuration
-        - SMDA stratigraphic units using the stratigraphic column identifier
-          from the project's masterdata configuration
+        The endpoint is a pure matching utility. Callers provide both the
+        source names and target names, and can optionally provide string
+        replacement rules to apply before matching.
 
-        The algorithm uses token-sort ratio for flexible name matching
-        that allows different word ordering.
+        Names are normalized before matching by lowercasing, replacing
+        underscores, dots, dashes, and slashes with spaces, collapsing
+        whitespace, and applying optional replacement rules. Replacement
+        rules match whole normalized token sequences only, so a rule like
+        `Fm -> Formation` changes `Tarbert Fm` to `Tarbert Formation`,
+        while `Top -> ""` leaves `Stop Viking` unchanged.
+
+        The response contains one result per source. Each result contains up
+        to three target matches, ordered from highest to lowest score.
 
         Confidence levels:
         - 'high': score > 80
         - 'medium': score 50-80
         - 'low': score < 50
-
-        Requirements:
-        - Project config must contain rms.zones
-        - Project config must contain masterdata.smda.stratigraphic_column.identifier
         """
     ),
-    responses={
-        **GetSessionResponses,
-        **MatchResponses,
-    },
+    responses=MatchResponses,
 )
-async def get_stratigraphy(
+async def post_match(
+    request: MatchRequest,
     match_service: MatchServiceDep,
-    smda_service: ProjectSmdaServiceDep,
-    project_session: ProjectSessionDep,
-) -> list[RmsStratigraphyMatch]:
-    """Match RMS zones to SMDA stratigraphic units.
-
-    This endpoint fetches both RMS zones and SMDA stratigraphic units
-    from the project configuration and returns the matching results.
-    """
-    try:
-        return await match_service.match_stratigraphy_from_config_to_smda(
-            project_session, smda_service
-        )
-    except ValueError as e:
-        error_msg = str(e)
-        status_code = 422 if "No stratigraphic units found" in error_msg else 400
-        raise HTTPException(
-            status_code=status_code,
-            detail=error_msg,
-            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
-        ) from e
-    except httpx.HTTPStatusError as e:
-        raise HTTPException(
-            status_code=e.response.status_code,
-            detail=f"SMDA error requesting {e.request.url}",
-            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
-        ) from e
-    except KeyError as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Malformed response from SMDA: {e}",
-            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
-        ) from e
-    except TimeoutError as e:
-        raise HTTPException(
-            status_code=503,
-            detail="SMDA API request timed out. Please try again.",
-            headers={HttpHeader.UPSTREAM_SOURCE_KEY: HttpHeader.UPSTREAM_SOURCE_SMDA},
-        ) from e
-
-
-@router.get(
-    "/coordinate_system",
-    response_model=RmsCoordinateSystemMatch,
-    summary="Match RMS coordinate system to SMDA coordinate systems",
-    description=dedent(
-        """
-        Match RMS coordinate system to SMDA coordinate system using
-        name similarity.
-
-        This endpoint automatically fetches:
-        - RMS coordinate system from the project configuration
-        - SMDA coordinate system from the project's masterdata configuration
-
-        The algorithm uses strict ratio matching for coordinate system names.
-
-        Confidence levels:
-        - 'high': score > 80
-        - 'medium': score 50-80
-        - 'low': score < 50
-
-        Requirements:
-        - Project config must contain rms.coordinate_system
-        - Project config must contain masterdata.smda.coordinate_system
-        """
-    ),
-    responses={
-        **GetSessionResponses,
-        **inline_add_response(
-            400,
-            "Required configuration is missing from the project config.",
-            [
-                {"detail": "RMS coordinate system not found in project configuration"},
-                {"detail": "SMDA coordinate system not found in masterdata"},
-            ],
-        ),
-    },
-)
-async def get_coordinate_system(
-    match_service: MatchServiceDep,
-    project_session: ProjectSessionDep,
-) -> RmsCoordinateSystemMatch:
-    """Match RMS coordinate system to SMDA coordinate system.
-
-    This endpoint fetches both RMS and SMDA coordinate systems
-    from the project configuration and returns the matching result.
-    """
-    try:
-        return match_service.match_coordinate_system_from_config_to_smda(
-            project_session
-        )
-    except ValueError as e:
-        raise HTTPException(
-            status_code=400,
-            detail=str(e),
-        ) from e
+) -> list[MatchResult]:
+    """Match source names to target names."""
+    return match_service.match_names(
+        request.sources,
+        request.targets,
+        request.replacements,
+    )

--- a/tests/test_services/test_match_service.py
+++ b/tests/test_services/test_match_service.py
@@ -1,17 +1,12 @@
 """Tests for the MatchService."""
 
-from collections.abc import Callable
-from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
-
 import pytest
-from fmu.datamodels.common.masterdata import CoordinateSystem
-from fmu.settings.models.project_config import RmsCoordinateSystem, RmsStratigraphicZone
-from httpx import HTTPStatusError, Request, Response
 
-from fmu_settings_api.models.match import RmsCoordinateSystemMatch
-from fmu_settings_api.models.smda import SmdaStratigraphicUnitsResult, StratigraphicUnit
+from fmu_settings_api.models.match import MatchReplacementRule
 from fmu_settings_api.services.match import MatchService
+
+PERFECT_MATCH_SCORE = 100.0
+LOW_CONFIDENCE_SCORE_THRESHOLD = 50
 
 
 @pytest.fixture
@@ -20,417 +15,218 @@ def match_service() -> MatchService:
     return MatchService()
 
 
-@pytest.fixture
-def mock_project_session() -> MagicMock:
-    """Returns a mock ProjectSession."""
-    session = MagicMock()
-    session.project_fmu_directory.get_config_value = MagicMock()
-    return session
+class TestMatchNames:
+    """Tests for match_names method."""
 
-
-@pytest.fixture
-def mock_smda_service() -> AsyncMock:
-    """Returns a mock SmdaService."""
-    return AsyncMock()
-
-
-class TestMatchZonesToUnits:
-    """Tests for match_zones_to_units method."""
-
-    def test_perfect_match(
-        self,
-        match_service: MatchService,
-        create_stratigraphic_unit: Callable[..., StratigraphicUnit],
-    ) -> None:
+    def test_perfect_match(self, match_service: MatchService) -> None:
         """Test matching with identical names returns 100 score."""
-        rms_zones = [
-            RmsStratigraphicZone(
-                name="Viking GP", top_horizon_name="Top", base_horizon_name="Base"
-            ),
-        ]
-        smda_units = [
-            create_stratigraphic_unit("Viking GP"),
-        ]
+        results = match_service.match_names(["Viking GP"], ["Viking GP"])
 
-        matches = match_service.match_stratigraphy(rms_zones, smda_units)
+        assert len(results) == 1
+        assert results[0].source == "Viking GP"
+        assert len(results[0].matches) == 1
+        assert results[0].matches[0].target == "Viking GP"
+        assert results[0].matches[0].score == PERFECT_MATCH_SCORE
+        assert results[0].matches[0].confidence == "high"
 
-        assert len(matches) == 1
-        assert matches[0].rms_zone.name == "Viking GP"
-        assert matches[0].smda_unit.identifier == "Viking GP"
-        assert matches[0].score == 100.0  # noqa: PLR2004
-        assert matches[0].confidence == "high"
-
-    def test_token_reordering(
-        self,
-        match_service: MatchService,
-        create_stratigraphic_unit: Callable[..., StratigraphicUnit],
+    def test_strict_matching_keeps_token_order(
+        self, match_service: MatchService
     ) -> None:
-        """Test matching handles token order differences."""
-        rms_zones = [
-            RmsStratigraphicZone(
-                name="Viking GP", top_horizon_name="Top", base_horizon_name="Base"
-            ),
-        ]
-        smda_units = [
-            create_stratigraphic_unit("GP Viking"),
-        ]
+        """Test matching does not treat reordered tokens as a perfect match."""
+        results = match_service.match_names(["Viking GP"], ["GP Viking"])
 
-        matches = match_service.match_stratigraphy(rms_zones, smda_units)
+        assert len(results) == 1
+        assert results[0].matches[0].score < PERFECT_MATCH_SCORE
 
-        assert len(matches) == 1
-        assert matches[0].score == 100  # noqa: PLR2004
-        assert matches[0].confidence in ["medium", "high"]
+    def test_name_normalization(self, match_service: MatchService) -> None:
+        """Test that names are normalized before matching."""
+        results = match_service.match_names(
+            ["Viking_GP-2/1"],
+            ["VIKING GP 2 1"],
+        )
 
-    def test_name_normalization(
-        self,
-        match_service: MatchService,
-        create_stratigraphic_unit: Callable[..., StratigraphicUnit],
+        assert len(results) == 1
+        assert results[0].matches[0].score == PERFECT_MATCH_SCORE
+        assert results[0].matches[0].confidence == "high"
+
+    def test_wellbore_name_matches_across_data_systems(
+        self, match_service: MatchService
     ) -> None:
-        """Test that names are normalized (lowercase, underscores, dots)."""
-        rms_zones = [
-            RmsStratigraphicZone(
-                name="Viking_GP.2.1", top_horizon_name="Top", base_horizon_name="Base"
-            ),
+        """Test matching an RMS wellbore name against various target system formats."""
+        results = match_service.match_names(
+            ["30_9-B-21_C"],
+            [
+                "B21C",
+                "NO 30/9-B-21 C",
+                "30/9-B-21 C",
+            ],
+            [MatchReplacementRule(original="NO", replacement="")],
+        )
+
+        assert len(results) == 1
+        assert results[0].source == "30_9-B-21_C"
+        expected_wellbore_match_count = 3
+        assert len(results[0].matches) == expected_wellbore_match_count
+        assert [
+            (match.target, match.score, match.confidence)
+            for match in results[0].matches
+        ] == [
+            ("NO 30/9-B-21 C", 100.0, "high"),
+            ("30/9-B-21 C", 100.0, "high"),
+            ("B21C", 53.333333333333336, "medium"),
         ]
-        smda_units = [
-            create_stratigraphic_unit("VIKING GP 2 1"),
-        ]
 
-        matches = match_service.match_stratigraphy(rms_zones, smda_units)
-
-        assert len(matches) == 1
-        assert matches[0].score == 100.0  # noqa: PLR2004
-        assert matches[0].confidence == "high"
-
-    def test_greedy_matching_each_zone_gets_best_match(
-        self,
-        match_service: MatchService,
-        create_stratigraphic_unit: Callable[..., StratigraphicUnit],
+    def test_replacements_are_applied_before_matching(
+        self, match_service: MatchService
     ) -> None:
-        """Test that greedy algorithm assigns each zone to its best matching unit."""
-        rms_zones = [
-            RmsStratigraphicZone(
-                name="Viking GP", top_horizon_name="Top", base_horizon_name="Base"
-            ),
-            RmsStratigraphicZone(
-                name="Tarbert Fm", top_horizon_name="Top", base_horizon_name="Base"
-            ),
-        ]
-        smda_units = [
-            create_stratigraphic_unit("Viking Group"),
-            create_stratigraphic_unit("Tarbert Formation"),
-            create_stratigraphic_unit("Unrelated Unit"),
-        ]
+        """Test that replacement rules are applied to source and target names."""
+        results = match_service.match_names(
+            ["Viking GP"],
+            ["Viking Group"],
+            [MatchReplacementRule(original="GP", replacement="Group")],
+        )
 
-        matches = match_service.match_stratigraphy(rms_zones, smda_units)
+        assert len(results) == 1
+        assert results[0].matches[0].score == PERFECT_MATCH_SCORE
+        assert results[0].matches[0].confidence == "high"
 
-        assert len(matches) == 2  # noqa: PLR2004
-        # Viking GP should match Viking Group
-        assert matches[0].rms_zone.name == "Viking GP"
-        assert "Viking" in matches[0].smda_unit.identifier
-        # Tarbert Fm should match Tarbert Formation
-        assert matches[1].rms_zone.name == "Tarbert Fm"
-        assert "Tarbert" in matches[1].smda_unit.identifier
-
-    def test_empty_rms_zones(
-        self,
-        match_service: MatchService,
-        create_stratigraphic_unit: Callable[..., StratigraphicUnit],
+    def test_replacement_rules_are_normalized(
+        self, match_service: MatchService
     ) -> None:
-        """Test matching with empty RMS zones returns empty list."""
-        rms_zones: list[RmsStratigraphicZone] = []
-        smda_units = [
-            create_stratigraphic_unit("Viking GP"),
-        ]
+        """Test replacement rules match normalized token sequences."""
+        results = match_service.match_names(
+            ["Viking G-P"],
+            ["Viking Group"],
+            [MatchReplacementRule(original="g_p", replacement="GROUP")],
+        )
 
-        matches = match_service.match_stratigraphy(rms_zones, smda_units)
+        assert len(results) == 1
+        assert results[0].matches[0].score == PERFECT_MATCH_SCORE
+        assert results[0].matches[0].confidence == "high"
 
-        assert matches == []
-
-    def test_empty_smda_units(
-        self,
-        match_service: MatchService,
-        create_stratigraphic_unit: Callable[..., StratigraphicUnit],
+    def test_replacements_do_not_apply_inside_tokens(
+        self, match_service: MatchService
     ) -> None:
-        """Test matching with empty SMDA units returns empty list."""
-        rms_zones = [
-            RmsStratigraphicZone(
-                name="Viking GP", top_horizon_name="Top", base_horizon_name="Base"
-            ),
-        ]
-        smda_units: list[StratigraphicUnit] = []
+        """Test replacement rules do not change text inside normalized tokens."""
+        results = match_service.match_names(
+            ["Stop Viking"],
+            ["S Viking"],
+            [MatchReplacementRule(original="Top", replacement="")],
+        )
 
-        matches = match_service.match_stratigraphy(rms_zones, smda_units)
+        assert len(results) == 1
+        assert results[0].matches[0].score < PERFECT_MATCH_SCORE
 
-        assert matches == []
+    def test_replacements_can_remove_strings(self, match_service: MatchService) -> None:
+        """Test that replacement rules can remove whole token sequences."""
+        results = match_service.match_names(
+            ["Top Viking GP"],
+            ["Viking GP"],
+            [MatchReplacementRule(original="Top", replacement="")],
+        )
 
-    def test_multiple_zones_preserved_order(
-        self,
-        match_service: MatchService,
-        create_stratigraphic_unit: Callable[..., StratigraphicUnit],
+        assert len(results) == 1
+        assert results[0].matches[0].score == PERFECT_MATCH_SCORE
+
+    def test_each_source_gets_top_three_matches(
+        self, match_service: MatchService
     ) -> None:
-        """Test that matching preserves the original zone order."""
-        rms_zones = [
-            RmsStratigraphicZone(
-                name="Zone A", top_horizon_name="Top", base_horizon_name="Base"
-            ),
-            RmsStratigraphicZone(
-                name="Zone B", top_horizon_name="Top", base_horizon_name="Base"
-            ),
-            RmsStratigraphicZone(
-                name="Zone C", top_horizon_name="Top", base_horizon_name="Base"
-            ),
-        ]
-        smda_units = [
-            create_stratigraphic_unit("Unit A"),
-            create_stratigraphic_unit("Unit B"),
-            create_stratigraphic_unit("Unit C"),
-        ]
+        """Test that each source gets up to three ranked target matches."""
+        results = match_service.match_names(
+            ["Viking GP"],
+            [
+                "Viking Group",
+                "Viking Formation",
+                "Viking",
+                "Unrelated Unit",
+            ],
+            [
+                MatchReplacementRule(original="GP", replacement="Group"),
+            ],
+        )
 
-        matches = match_service.match_stratigraphy(rms_zones, smda_units)
+        assert len(results) == 1
+        assert results[0].source == "Viking GP"
+        expected_top_match_count = 3
+        assert len(results[0].matches) == expected_top_match_count
+        assert results[0].matches[0].target == "Viking Group"
+        assert results[0].matches[0].score >= results[0].matches[1].score
+        assert results[0].matches[1].score >= results[0].matches[2].score
+        assert {match.target for match in results[0].matches} == {
+            "Viking Group",
+            "Viking Formation",
+            "Viking",
+        }
 
-        assert len(matches) == 3  # noqa: PLR2004
-        assert matches[0].rms_zone.name == "Zone A"
-        assert matches[1].rms_zone.name == "Zone B"
-        assert matches[2].rms_zone.name == "Zone C"
+    def test_returns_fewer_matches_when_less_than_three_targets(
+        self, match_service: MatchService
+    ) -> None:
+        """Test that each source gets all targets when fewer than three exist."""
+        results = match_service.match_names(
+            ["Viking GP", "Tarbert Fm"],
+            ["Viking GP", "Tarbert Fm"],
+        )
 
+        expected_source_count = 2
+        assert len(results) == expected_source_count
+        assert [match.source for match in results] == ["Viking GP", "Tarbert Fm"]
+        expected_match_count_per_source = 2
+        assert len(results[0].matches) == expected_match_count_per_source
+        assert len(results[1].matches) == expected_match_count_per_source
 
-class TestMatchCoordinateSystems:
-    """Tests for match_coordinate_system method."""
+    def test_multiple_sources_get_grouped_matches(
+        self, match_service: MatchService
+    ) -> None:
+        """Test each source result contains only its own target candidates."""
+        results = match_service.match_names(
+            ["Viking GP", "Tarbert Fm"],
+            ["Viking Group", "Tarbert Formation", "Unrelated Unit"],
+            [
+                MatchReplacementRule(original="GP", replacement="Group"),
+                MatchReplacementRule(original="Fm", replacement="Formation"),
+            ],
+        )
 
-    def test_exact_match(self, match_service: MatchService) -> None:
-        """Test coordinate system matching with exact names."""
-        rms_crs = RmsCoordinateSystem(name="ED50 UTM31")
-        smda_crs = CoordinateSystem(identifier="ED50 UTM31", uuid=uuid4())
+        expected_source_count = 2
+        assert len(results) == expected_source_count
+        assert results[0].source == "Viking GP"
+        assert results[0].matches[0].target == "Viking Group"
+        assert results[1].source == "Tarbert Fm"
+        assert results[1].matches[0].target == "Tarbert Formation"
 
-        match = match_service.match_coordinate_system(rms_crs, smda_crs)
+    def test_empty_sources(self, match_service: MatchService) -> None:
+        """Test matching with empty sources returns an empty list."""
+        results = match_service.match_names([], ["Viking GP"])
 
-        assert isinstance(match, RmsCoordinateSystemMatch)
-        assert match.rms_crs_sys.name == "ED50 UTM31"
-        assert match.smda_crs_sys.identifier == "ED50 UTM31"
-        assert match.score == 100.0  # noqa: PLR2004
-        assert match.confidence == "high"
+        assert results == []
 
-    def test_partial_match_medium_confidence(self, match_service: MatchService) -> None:
-        """Test coordinate system matching with similar names."""
-        rms_crs = RmsCoordinateSystem(name="ED50 UTM Zone 31")
-        smda_crs = CoordinateSystem(identifier="ED50 UTM31", uuid=uuid4())
+    def test_empty_targets(self, match_service: MatchService) -> None:
+        """Test matching with empty targets returns sources with empty matches."""
+        results = match_service.match_names(["Viking GP"], [])
 
-        match = match_service.match_coordinate_system(rms_crs, smda_crs)
+        assert len(results) == 1
+        assert results[0].source == "Viking GP"
+        assert results[0].matches == []
 
-        assert 50 <= match.score <= 80  # noqa: PLR2004
-        assert match.confidence == "medium"
+    def test_multiple_sources_preserved_order(
+        self, match_service: MatchService
+    ) -> None:
+        """Test that matching preserves the original source order."""
+        results = match_service.match_names(
+            ["Zone A", "Zone B", "Zone C"],
+            ["Unit A"],
+        )
+
+        expected_source_count = 3
+        assert len(results) == expected_source_count
+        assert results[0].source == "Zone A"
+        assert results[1].source == "Zone B"
+        assert results[2].source == "Zone C"
 
     def test_low_confidence_match(self, match_service: MatchService) -> None:
         """Test matching with very different names returns low confidence."""
-        rms_crs = RmsCoordinateSystem(name="ED50")
-        smda_crs = CoordinateSystem(identifier="WGS84 UTM Zone 32", uuid=uuid4())
+        results = match_service.match_names(["ED50"], ["WGS84 UTM Zone 32"])
 
-        match = match_service.match_coordinate_system(rms_crs, smda_crs)
-
-        assert match.score < 50  # noqa: PLR2004
-        assert match.confidence == "low"
-
-    def test_normalization(self, match_service: MatchService) -> None:
-        """Test that coordinate system names are normalized."""
-        rms_crs = RmsCoordinateSystem(name="ED50_UTM.31")
-        smda_crs = CoordinateSystem(identifier="ED50 UTM 31", uuid=uuid4())
-
-        match = match_service.match_coordinate_system(rms_crs, smda_crs)
-
-        assert match.score == 100.0  # noqa: PLR2004
-        assert match.confidence == "high"
-
-
-class TestMatchStratigraphyFromConfigToSmda:
-    """Tests for match_stratigraphy_from_config_to_smda method."""
-
-    async def test_success(
-        self,
-        match_service: MatchService,
-        mock_project_session: MagicMock,
-        mock_smda_service: AsyncMock,
-        create_stratigraphic_unit: Callable[..., StratigraphicUnit],
-    ) -> None:
-        """Test successful matching from config to SMDA."""
-        config = {
-            "rms.zones": [
-                {
-                    "name": "Viking GP",
-                    "top_horizon_name": "Top",
-                    "base_horizon_name": "Base",
-                }
-            ],
-            "masterdata.smda.stratigraphic_column.identifier": "NSO_SP_1984",
-        }
-        mock_project_session.project_fmu_directory.get_config_value.side_effect = (
-            config.get
-        )
-
-        smda_units = [create_stratigraphic_unit("Viking Group")]
-        mock_smda_service.get_stratigraphic_units.return_value = (
-            SmdaStratigraphicUnitsResult(stratigraphic_units=smda_units)
-        )
-
-        matches = await match_service.match_stratigraphy_from_config_to_smda(
-            mock_project_session, mock_smda_service
-        )
-
-        assert len(matches) == 1
-        assert matches[0].rms_zone.name == "Viking GP"
-        assert matches[0].smda_unit.identifier == "Viking Group"
-        mock_smda_service.get_stratigraphic_units.assert_called_once_with("NSO_SP_1984")
-
-    async def test_missing_rms_zones_config(
-        self,
-        match_service: MatchService,
-        mock_project_session: MagicMock,
-        mock_smda_service: AsyncMock,
-    ) -> None:
-        """Test ValueError when rms.zones is missing from config."""
-        mock_project_session.project_fmu_directory.get_config_value.return_value = None
-
-        with pytest.raises(ValueError, match="No RMS zones found in project config"):
-            await match_service.match_stratigraphy_from_config_to_smda(
-                mock_project_session, mock_smda_service
-            )
-
-    async def test_missing_stratigraphic_column_identifier(
-        self,
-        match_service: MatchService,
-        mock_project_session: MagicMock,
-        mock_smda_service: AsyncMock,
-    ) -> None:
-        """Test ValueError when stratigraphic column identifier is missing."""
-        config = {
-            "rms.zones": [
-                {
-                    "name": "Viking GP",
-                    "top_horizon_name": "Top",
-                    "base_horizon_name": "Base",
-                }
-            ],
-        }
-        mock_project_session.project_fmu_directory.get_config_value.side_effect = (
-            config.get
-        )
-
-        with pytest.raises(
-            ValueError, match="No stratigraphic column identifier found"
-        ):
-            await match_service.match_stratigraphy_from_config_to_smda(
-                mock_project_session, mock_smda_service
-            )
-
-    @pytest.mark.parametrize(
-        ("error_type", "error_instance"),
-        [
-            (
-                HTTPStatusError,
-                HTTPStatusError(
-                    "404 Not Found",
-                    request=Request("GET", "http://smda.com"),
-                    response=Response(404),
-                ),
-            ),
-            (KeyError, KeyError("malformed response")),
-            (TimeoutError, TimeoutError("Request timeout")),
-        ],
-    )
-    async def test_propagates_smda_errors(
-        self,
-        match_service: MatchService,
-        mock_project_session: MagicMock,
-        mock_smda_service: AsyncMock,
-        error_type: type[Exception],
-        error_instance: Exception,
-    ) -> None:
-        """Test that errors from SMDA service are propagated."""
-        config = {
-            "rms.zones": [
-                {
-                    "name": "Viking GP",
-                    "top_horizon_name": "Top",
-                    "base_horizon_name": "Base",
-                }
-            ],
-            "masterdata.smda.stratigraphic_column.identifier": "NSO_SP_1984",
-        }
-        mock_project_session.project_fmu_directory.get_config_value.side_effect = (
-            config.get
-        )
-
-        mock_smda_service.get_stratigraphic_units.side_effect = error_instance
-
-        with pytest.raises(error_type):
-            await match_service.match_stratigraphy_from_config_to_smda(
-                mock_project_session, mock_smda_service
-            )
-
-
-class TestMatchCoordinateSystemFromConfig:
-    """Tests for match_coordinate_system_from_config_to_smda method."""
-
-    def test_success(
-        self, match_service: MatchService, mock_project_session: MagicMock
-    ) -> None:
-        """Test successful coordinate system matching from config."""
-        config = {
-            "rms.coordinate_system": {
-                "name": "ED50 UTM31",
-                "projection": "utm",
-                "datum": "ED50",
-            },
-            "masterdata.smda.coordinate_system": {
-                "identifier": "ED50 UTM31",
-                "uuid": str(uuid4()),
-            },
-        }
-        mock_project_session.project_fmu_directory.get_config_value.side_effect = (
-            config.get
-        )
-
-        match = match_service.match_coordinate_system_from_config_to_smda(
-            mock_project_session
-        )
-
-        assert isinstance(match, RmsCoordinateSystemMatch)
-        assert match.rms_crs_sys.name == "ED50 UTM31"
-        assert match.smda_crs_sys.identifier == "ED50 UTM31"
-        assert match.score == 100.0  # noqa: PLR2004
-        assert match.confidence == "high"
-
-    def test_missing_rms_coordinate_system(
-        self, match_service: MatchService, mock_project_session: MagicMock
-    ) -> None:
-        """Test ValueError when rms.coordinate_system is missing."""
-        mock_project_session.project_fmu_directory.get_config_value.return_value = None
-
-        with pytest.raises(
-            ValueError, match="No RMS coordinate system found in project config"
-        ):
-            match_service.match_coordinate_system_from_config_to_smda(
-                mock_project_session
-            )
-
-    def test_missing_smda_coordinate_system(
-        self, match_service: MatchService, mock_project_session: MagicMock
-    ) -> None:
-        """Test ValueError when smda.coordinate_system is missing."""
-        config = {
-            "rms.coordinate_system": {
-                "name": "ED50 UTM31",
-                "projection": "utm",
-                "datum": "ED50",
-            },
-        }
-        mock_project_session.project_fmu_directory.get_config_value.side_effect = (
-            config.get
-        )
-
-        with pytest.raises(
-            ValueError, match="No SMDA coordinate system found in project masterdata"
-        ):
-            match_service.match_coordinate_system_from_config_to_smda(
-                mock_project_session
-            )
+        assert len(results) == 1
+        assert results[0].matches[0].score < LOW_CONFIDENCE_SCORE_THRESHOLD
+        assert results[0].matches[0].confidence == "low"

--- a/tests/test_v1/test_match.py
+++ b/tests/test_v1/test_match.py
@@ -1,270 +1,102 @@
 """Tests for the /api/v1/match routes."""
 
-from collections.abc import Callable
-from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
-
-import httpx
+import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
-from fmu.datamodels.common.masterdata import CoordinateSystem
-from fmu.settings.models.project_config import RmsCoordinateSystem, RmsStratigraphicZone
 
 from fmu_settings_api.__main__ import app
-from fmu_settings_api.config import HttpHeader
-from fmu_settings_api.deps.match import get_match_service
-from fmu_settings_api.deps.smda import get_project_smda_service
-from fmu_settings_api.models.match import (
-    RmsCoordinateSystemMatch,
-    RmsStratigraphyMatch,
-)
-from fmu_settings_api.models.smda import StratigraphicUnit
 
 ROUTE = "/api/v1/match"
+PERFECT_MATCH_SCORE = 100.0
 
 
-class TestGetStratigraphyEndpoint:
-    """Tests for GET /api/v1/match/stratigraphy endpoint."""
+class TestPostMatchEndpoint:
+    """Tests for POST /api/v1/match endpoint."""
 
-    def test_no_session(self) -> None:
-        """Test 401 when no session is active."""
+    def test_successful_match(self) -> None:
+        """Test successful matching returns grouped match results."""
         with TestClient(app) as client:
-            response = client.get(f"{ROUTE}/stratigraphy")
-            assert response.status_code == status.HTTP_401_UNAUTHORIZED
-            assert response.json()["detail"] == "No active session found"
-
-    async def test_success(
-        self,
-        client_with_smda_session: TestClient,
-        create_stratigraphic_unit: Callable[..., StratigraphicUnit],
-    ) -> None:
-        """Test successful stratigraphy matching."""
-        mock_match_service = AsyncMock()
-        mock_smda_service = AsyncMock()
-
-        expected_matches = [
-            RmsStratigraphyMatch(
-                rms_zone=RmsStratigraphicZone(
-                    name="Viking GP",
-                    top_horizon_name="Top",
-                    base_horizon_name="Base",
-                ),
-                smda_unit=create_stratigraphic_unit("Viking Group"),
-                score=85.0,
-                confidence="high",
+            response = client.post(
+                ROUTE,
+                json={
+                    "sources": ["Viking GP"],
+                    "targets": ["Viking Group"],
+                    "replacements": [{"original": "GP", "replacement": "Group"}],
+                },
             )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json() == [
+            {
+                "source": "Viking GP",
+                "matches": [
+                    {
+                        "target": "Viking Group",
+                        "score": 100.0,
+                        "confidence": "high",
+                    }
+                ],
+            }
         ]
-        mock_match_service.match_stratigraphy_from_config_to_smda.return_value = (
-            expected_matches
-        )
 
-        app.dependency_overrides[get_match_service] = lambda: mock_match_service
-        app.dependency_overrides[get_project_smda_service] = lambda: mock_smda_service
-
-        response = client_with_smda_session.get(f"{ROUTE}/stratigraphy")
-
-        assert response.status_code == status.HTTP_200_OK
-        result = response.json()
-        assert len(result) == 1
-        assert result[0]["rms_zone"]["name"] == "Viking GP"
-        assert result[0]["smda_unit"]["identifier"] == "Viking Group"
-        assert result[0]["score"] == 85.0  # noqa: PLR2004
-        assert result[0]["confidence"] == "high"
-
-    async def test_missing_rms_zones_config(
-        self, client_with_smda_session: TestClient
-    ) -> None:
-        """Test 400 when rms.zones config is missing."""
-        mock_match_service = AsyncMock()
-        mock_smda_service = AsyncMock()
-
-        mock_match_service.match_stratigraphy_from_config_to_smda.side_effect = (
-            ValueError("No RMS zones found in project config")
-        )
-
-        app.dependency_overrides[get_match_service] = lambda: mock_match_service
-        app.dependency_overrides[get_project_smda_service] = lambda: mock_smda_service
-
-        response = client_with_smda_session.get(f"{ROUTE}/stratigraphy")
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "No RMS zones found in project config" in response.json()["detail"]
-
-    async def test_missing_stratigraphic_column_identifier(
-        self, client_with_smda_session: TestClient
-    ) -> None:
-        """Test 400 when stratigraphic column identifier is missing."""
-        mock_match_service = AsyncMock()
-        mock_smda_service = AsyncMock()
-
-        mock_match_service.match_stratigraphy_from_config_to_smda.side_effect = (
-            ValueError("No stratigraphic column identifier found")
-        )
-
-        app.dependency_overrides[get_match_service] = lambda: mock_match_service
-        app.dependency_overrides[get_project_smda_service] = lambda: mock_smda_service
-
-        response = client_with_smda_session.get(f"{ROUTE}/stratigraphy")
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "No stratigraphic column identifier found" in response.json()["detail"]
-
-    async def test_no_stratigraphic_units_found(
-        self, client_with_smda_session: TestClient
-    ) -> None:
-        """Test 200 with empty list when no stratigraphic units found for matching."""
-        mock_match_service = AsyncMock()
-        mock_smda_service = AsyncMock()
-
-        mock_match_service.match_stratigraphy_from_config_to_smda.return_value = []
-
-        app.dependency_overrides[get_match_service] = lambda: mock_match_service
-        app.dependency_overrides[get_project_smda_service] = lambda: mock_smda_service
-
-        response = client_with_smda_session.get(f"{ROUTE}/stratigraphy")
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == []
-
-    async def test_smda_http_error(self, client_with_smda_session: TestClient) -> None:
-        """Test that SMDA HTTPStatusError is properly propagated."""
-        mock_match_service = AsyncMock()
-        mock_smda_service = AsyncMock()
-
-        mock_request = MagicMock(spec=httpx.Request)
-        mock_request.url = "https://smda.example.com/endpoint"
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 404
-
-        mock_match_service.match_stratigraphy_from_config_to_smda.side_effect = (
-            httpx.HTTPStatusError(
-                "404 Not Found",
-                request=mock_request,
-                response=mock_response,
-            )
-        )
-
-        app.dependency_overrides[get_match_service] = lambda: mock_match_service
-        app.dependency_overrides[get_project_smda_service] = lambda: mock_smda_service
-
-        response = client_with_smda_session.get(f"{ROUTE}/stratigraphy")
-
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert (
-            response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
-            == HttpHeader.UPSTREAM_SOURCE_SMDA
-        )
-
-    async def test_smda_malformed_response(
-        self, client_with_smda_session: TestClient
-    ) -> None:
-        """Test 500 when SMDA returns malformed response."""
-        mock_match_service = AsyncMock()
-        mock_smda_service = AsyncMock()
-
-        mock_match_service.match_stratigraphy_from_config_to_smda.side_effect = (
-            KeyError("stratigraphic_units")
-        )
-
-        app.dependency_overrides[get_match_service] = lambda: mock_match_service
-        app.dependency_overrides[get_project_smda_service] = lambda: mock_smda_service
-
-        response = client_with_smda_session.get(f"{ROUTE}/stratigraphy")
-
-        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-        assert (
-            response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
-            == HttpHeader.UPSTREAM_SOURCE_SMDA
-        )
-        assert "Malformed response from SMDA" in response.json()["detail"]
-
-    async def test_smda_timeout(self, client_with_smda_session: TestClient) -> None:
-        """Test 503 when SMDA request times out."""
-        mock_match_service = AsyncMock()
-        mock_smda_service = AsyncMock()
-
-        mock_match_service.match_stratigraphy_from_config_to_smda.side_effect = (
-            TimeoutError("Request timed out")
-        )
-
-        app.dependency_overrides[get_match_service] = lambda: mock_match_service
-        app.dependency_overrides[get_project_smda_service] = lambda: mock_smda_service
-
-        response = client_with_smda_session.get(f"{ROUTE}/stratigraphy")
-
-        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
-        assert (
-            response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
-            == HttpHeader.UPSTREAM_SOURCE_SMDA
-        )
-        assert "timed out" in response.json()["detail"]
-
-
-class TestGetCoordinateSystemEndpoint:
-    """Tests for GET /api/v1/match/coordinate_system endpoint."""
-
-    def test_no_session(self) -> None:
-        """Test 401 when no session is active."""
+    def test_replacements_are_optional(self) -> None:
+        """Test matching succeeds when replacements are omitted."""
         with TestClient(app) as client:
-            response = client.get(f"{ROUTE}/coordinate_system")
-            assert response.status_code == status.HTTP_401_UNAUTHORIZED
-            assert response.json()["detail"] == "No active session found"
+            response = client.post(
+                ROUTE,
+                json={
+                    "sources": ["Viking-GP"],
+                    "targets": ["Viking GP"],
+                },
+            )
 
-    async def test_success(self, client_with_project_session: TestClient) -> None:
-        """Test successful coordinate system matching."""
-        mock_match_service = MagicMock()
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json()[0]["matches"][0]["score"] == PERFECT_MATCH_SCORE
 
-        expected_match = RmsCoordinateSystemMatch(
-            rms_crs_sys=RmsCoordinateSystem(name="ED50 UTM31"),
-            smda_crs_sys=CoordinateSystem(identifier="ED50 UTM31", uuid=uuid4()),
-            score=100.0,
-            confidence="high",
-        )
-        mock_match_service.match_coordinate_system_from_config_to_smda.return_value = (
-            expected_match
-        )
+    def test_empty_targets_returns_source_with_empty_matches(self) -> None:
+        """Test matching with no targets returns source with no matches."""
+        with TestClient(app) as client:
+            response = client.post(
+                ROUTE,
+                json={
+                    "sources": ["Viking GP"],
+                    "targets": [],
+                },
+            )
 
-        app.dependency_overrides[get_match_service] = lambda: mock_match_service
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json() == [{"source": "Viking GP", "matches": []}]
 
-        response = client_with_project_session.get(f"{ROUTE}/coordinate_system")
+    def test_invalid_payload_returns_validation_error(self) -> None:
+        """Test invalid request body returns 422."""
+        with TestClient(app) as client:
+            response = client.post(
+                ROUTE,
+                json={
+                    "sources": "Viking GP",
+                    "targets": ["Viking GP"],
+                },
+            )
 
-        assert response.status_code == status.HTTP_200_OK
-        result = response.json()
-        assert result["rms_crs_sys"]["name"] == "ED50 UTM31"
-        assert result["smda_crs_sys"]["identifier"] == "ED50 UTM31"
-        assert result["score"] == 100.0  # noqa: PLR2004
-        assert result["confidence"] == "high"
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
-    async def test_missing_rms_coordinate_system(
-        self, client_with_project_session: TestClient
+    @pytest.mark.parametrize("original", ["", "_"])
+    def test_empty_replacement_original_returns_validation_error(
+        self, original: str
     ) -> None:
-        """Test 400 when rms.coordinate_system config is missing."""
-        mock_match_service = MagicMock()
+        """Test replacement rules must have a useful original value."""
+        with TestClient(app) as client:
+            response = client.post(
+                ROUTE,
+                json={
+                    "sources": ["Viking GP"],
+                    "targets": ["Viking Group"],
+                    "replacements": [{"original": original, "replacement": "Group"}],
+                },
+            )
 
-        mock_match_service.match_coordinate_system_from_config_to_smda.side_effect = (
-            ValueError("No RMS coordinate system found in project config")
-        )
-
-        app.dependency_overrides[get_match_service] = lambda: mock_match_service
-
-        response = client_with_project_session.get(f"{ROUTE}/coordinate_system")
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "No RMS coordinate system found" in response.json()["detail"]
-
-    async def test_missing_smda_coordinate_system(
-        self, client_with_project_session: TestClient
-    ) -> None:
-        """Test 400 when smda coordinate system is missing from masterdata."""
-        mock_match_service = MagicMock()
-
-        mock_match_service.match_coordinate_system_from_config_to_smda.side_effect = (
-            ValueError("No SMDA coordinate system found in project masterdata")
-        )
-
-        app.dependency_overrides[get_match_service] = lambda: mock_match_service
-
-        response = client_with_project_session.get(f"{ROUTE}/coordinate_system")
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "No SMDA coordinate system found" in response.json()["detail"]
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        error_message = response.json()["detail"][0]["msg"]
+        assert "Original must include text after normalization" in error_message
+        assert 'separators such as "_", ".", "-", and "/"' in error_message
+        assert '"Fm" -> "Formation"' in error_message


### PR DESCRIPTION
Resolves #378

Simplified the match endpoint into a generic name matching utility. The endpoint now accepts caller provided sources, targets, and optional replacement rules, returns grouped top 3 candidate matches per source, and no longer reads project config or calls SMDA.

Removed coordinate-system matching from the match API and replaced RMS/SMDA-specific match models with generic request/result models.

## Example

Request:

```json
{
  "sources": ["Viking GP", "Tarbert_Fm"],
  "targets": [
    "Viking Group",
    "Viking Formation",
    "Tarbert Formation",
    "Unrelated Unit"
  ],
  "replacements": [
    { "original": "GP", "replacement": "Group" },
    { "original": "Fm", "replacement": "Formation" }
  ]
}
```

Result:

```json
[
  {
    "source": "Viking GP",
    "matches": [
      {
        "target": "Viking Group",
        "score": 100,
        "confidence": "high"
      },
      {
        "target": "Viking Formation",
        "score": 64.28571428571428,
        "confidence": "medium"
      },
      {
        "target": "Unrelated Unit",
        "score": 23.076923076923073,
        "confidence": "low"
      }
    ]
  },
  {
    "source": "Tarbert_Fm",
    "matches": [
      {
        "target": "Tarbert Formation",
        "score": 100,
        "confidence": "high"
      },
      {
        "target": "Viking Formation",
        "score": 60.60606060606061,
        "confidence": "medium"
      },
      {
        "target": "Unrelated Unit",
        "score": 32.25806451612904,
        "confidence": "low"
      }
    ]
  }
]
```

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
