### PR TITLE
ENH: Handle missing RMS project errors in POST /rms

### DIFF
--- a/src/fmu_settings_api/services/rms.py
+++ b/src/fmu_settings_api/services/rms.py
@@ -39,7 +39,7 @@ class RmsService:
             rms_config = RmsConfig(project=str(rms_project_path))
         except RmsProjectNotFoundError as e:
             raise FileNotFoundError(
-                f"RMS project not found at '{rms_project_path}': {str(e)}"
+                f"RMS project not found at '{rms_project_path}'."
             ) from e
         except FileNotFoundError as e:
             raise FileNotFoundError(

--- a/src/fmu_settings_api/v1/routes/rms.py
+++ b/src/fmu_settings_api/v1/routes/rms.py
@@ -61,12 +61,18 @@ FailedOpeningRmsProjectResponses: Final[Responses] = {
     ),
     **inline_add_response(
         404,
-        dedent("RMS project does not exist at the configured path."),
+        dedent("RMS project or its .master file was not found."),
         [
             {
                 "detail": (
                     "RMS project does not exist at the "
                     "configured path: {rms_project_path}."
+                )
+            },
+            {
+                "detail": (
+                    "RMS project .master file not found at "
+                    "'{rms_project_path}': {string content of exception}"
                 )
             },
         ],
@@ -121,12 +127,15 @@ async def post_rms_project(
     rms_version: RmsVersion | None = None,
 ) -> Message:
     """Open an RMS project and store it in the session."""
-    try:
-        version = (
-            rms_version.version
-            if rms_version is not None
-            else rms_service.get_rms_version(rms_project_path)
+    version = rms_version.version if rms_version is not None else None
+    if version is not None and not rms_project_path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=f"RMS project not found at '{rms_project_path}'.",
         )
+    try:
+        if version is None:
+            version = rms_service.get_rms_version(rms_project_path)
         executor, project = rms_service.open_rms_project(rms_project_path, version)
         await session_service.add_rms_session(executor, project)
         return Message(
@@ -142,6 +151,8 @@ async def post_rms_project(
                 f"configured path: {rms_project_path}."
             ),
         ) from e
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except RmsVersionError as e:
         raise HTTPException(
             status_code=422,

--- a/tests/test_v1/test_rms.py
+++ b/tests/test_v1/test_rms.py
@@ -160,6 +160,27 @@ async def test_open_rms_project_not_found(
     }
 
 
+async def test_open_rms_project_not_found_without_specified_version(
+    client_with_project_session: TestClient,
+    tmp_path: Path,
+) -> None:
+    """Test project not found while detecting the RMS version."""
+    mock_service = MagicMock()
+    rms_path = tmp_path / "missing-project.rms15.0.1.0"
+    error_message = f"RMS project not found at '{rms_path}'."
+    mock_service.get_rms_version.side_effect = FileNotFoundError(error_message)
+
+    app.dependency_overrides[get_rms_service] = lambda: mock_service
+    app.dependency_overrides[get_rms_project_path] = lambda: rms_path
+
+    response = client_with_project_session.post(f"{ROUTE}/")
+
+    mock_service.get_rms_version.assert_called_once_with(rms_path)
+    mock_service.open_rms_project.assert_not_called()
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": error_message}
+
+
 async def test_open_rms_project_with_specified_version_not_found(
     client_with_project_session: TestClient,
     tmp_path: Path,

--- a/tests/test_v1/test_rms.py
+++ b/tests/test_v1/test_rms.py
@@ -45,6 +45,7 @@ async def test_open_rms_project_success(
 
 async def test_open_rms_project_with_specified_version(
     client_with_project_session: TestClient,
+    tmp_path: Path,
 ) -> None:
     """Test opening an RMS project with a specified RMS version."""
     default_rms_version = "14.2.2"
@@ -54,7 +55,8 @@ async def test_open_rms_project_with_specified_version(
     mock_service.open_rms_project.return_value = (MagicMock(), MagicMock())
     mock_service.get_rms_version.return_value = default_rms_version
 
-    rms_path = Path("/path/to/rms/project")
+    rms_path = tmp_path / "project.rms15.1.0.0"
+    rms_path.mkdir()
 
     app.dependency_overrides[get_rms_service] = lambda: mock_service
     app.dependency_overrides[get_rms_project_path] = lambda: rms_path
@@ -158,13 +160,56 @@ async def test_open_rms_project_not_found(
     }
 
 
+async def test_open_rms_project_with_specified_version_not_found(
+    client_with_project_session: TestClient,
+    tmp_path: Path,
+) -> None:
+    """Test explicit RMS version does not start RMS when project path is missing."""
+    mock_service = MagicMock()
+    rms_path = tmp_path / "missing-project.rms15.0.1.0"
+
+    app.dependency_overrides[get_rms_service] = lambda: mock_service
+    app.dependency_overrides[get_rms_project_path] = lambda: rms_path
+
+    response = client_with_project_session.post(ROUTE, json={"version": "15.0.1.0"})
+
+    mock_service.get_rms_version.assert_not_called()
+    mock_service.open_rms_project.assert_not_called()
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {
+        "detail": f"RMS project not found at '{rms_path}'.",
+    }
+
+
+async def test_open_rms_project_master_file_not_found(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test opening an RMS project when its .master file does not exist."""
+    mock_service = MagicMock()
+    rms_path = Path("/path/to/rms/project")
+    error_message = f"RMS project .master file not found at '{rms_path}'."
+    mock_service.get_rms_version.side_effect = FileNotFoundError(error_message)
+
+    app.dependency_overrides[get_rms_service] = lambda: mock_service
+    app.dependency_overrides[get_rms_project_path] = lambda: rms_path
+
+    response = client_with_project_session.post(f"{ROUTE}/")
+
+    mock_service.get_rms_version.assert_called_once_with(rms_path)
+    mock_service.open_rms_project.assert_not_called()
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": error_message}
+
+
 async def test_open_rms_project_unsupported_version(
     client_with_project_session: TestClient,
+    tmp_path: Path,
 ) -> None:
     """Tests opening an RMS project with an unsupported RMS version."""
     mock_service = MagicMock()
     specified_rms_version = "15.0.1.0"
-    rms_path = Path("/path/to/rms/project")
+    rms_path = tmp_path / "project.rms15.0.1.0"
+    rms_path.mkdir()
 
     mock_service.open_rms_project.side_effect = RmsVersionError(
         f"RMS version {specified_rms_version} is not supported."
@@ -188,13 +233,42 @@ async def test_open_rms_project_unsupported_version(
     }
 
 
+async def test_open_rms_project_detected_version_unsupported(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test unsupported RMS version found while reading project metadata."""
+    mock_service = MagicMock()
+    rms_path = Path("/path/to/rms/project")
+    error_message = f"RMS version error for project at '{rms_path}'."
+    mock_service.get_rms_version.side_effect = RmsVersionError(error_message)
+
+    app.dependency_overrides[get_rms_service] = lambda: mock_service
+    app.dependency_overrides[get_rms_project_path] = lambda: rms_path
+
+    response = client_with_project_session.post(f"{ROUTE}/")
+
+    mock_service.get_rms_version.assert_called_once_with(rms_path)
+    mock_service.open_rms_project.assert_not_called()
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert response.json() == {
+        "detail": (
+            f"Failed to open RMS project {rms_path}: Failed setting up RMS "
+            "API proxy: The requested RMS version None is not supported. "
+            "Try specifying another RMS version "
+            "or upgrading the RMS project."
+        )
+    }
+
+
 async def test_open_rms_project_version_out_of_sync(
     client_with_project_session: TestClient,
+    tmp_path: Path,
 ) -> None:
     """Tests opening an RMS project with a version out of sync with the project."""
     mock_service = MagicMock()
     specified_rms_version = "15.0.1.0"
-    rms_path = Path("/path/to/old/rms/project")
+    rms_path = tmp_path / "old-project.rms13.1.0"
+    rms_path.mkdir()
 
     remote_exception = RemoteException(
         message="File version xxxx.xxxx is not supported."


### PR DESCRIPTION
Resolves #392

This updates `POST /rms/` error handling so missing RMS project paths, missing `.master` files, and unsupported detected RMS versions are mapped to useful HTTP responses.

The route now avoids starting the RMS API worker when an explicit RMS version is supplied but the configured RMS project path does not exist. It also preserves 404 handling for missing project metadata while detecting the version, and documents the additional 404 responses.

With this change, we will see this:
<img width="1613" height="434" alt="image" src="https://github.com/user-attachments/assets/c52c7142-da50-4915-a416-60fbbd48e223" />
There's a duplicate error for now because the GUI retries when it can't open RMS project. Made this issue to fix that https://github.com/equinor/fmu-settings-gui/issues/430

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist