### PR TITLE
ENH: Improve RMS .master missing error message

### DIFF
--- a/src/fmu_settings_api/services/rms.py
+++ b/src/fmu_settings_api/services/rms.py
@@ -43,7 +43,8 @@ class RmsService:
             ) from e
         except FileNotFoundError as e:
             raise FileNotFoundError(
-                f"RMS project .master file not found at '{rms_project_path}': {str(e)}"
+                "RMS version cannot be determined because the RMS project "
+                f".master file is not found at {rms_project_path}."
             ) from e
         except RmsVersionError as e:
             raise RmsVersionError(

--- a/src/fmu_settings_api/v1/routes/rms.py
+++ b/src/fmu_settings_api/v1/routes/rms.py
@@ -61,7 +61,7 @@ FailedOpeningRmsProjectResponses: Final[Responses] = {
     ),
     **inline_add_response(
         404,
-        dedent("RMS project or its .master file was not found."),
+        dedent("RMS project was not found or its version could not be determined."),
         [
             {
                 "detail": (
@@ -71,8 +71,8 @@ FailedOpeningRmsProjectResponses: Final[Responses] = {
             },
             {
                 "detail": (
-                    "RMS project .master file not found at "
-                    "'{rms_project_path}': {string content of exception}"
+                    "RMS version cannot be determined because the RMS project "
+                    ".master file is not found at {rms_project_path}."
                 )
             },
         ],

--- a/tests/test_services/test_rms_service.py
+++ b/tests/test_services/test_rms_service.py
@@ -77,8 +77,10 @@ def test_get_rms_version_master_file_not_found(rms_service: RmsService) -> None:
     ):
         rms_service.get_rms_version(rms_project_path)
 
-    assert "RMS project .master file not found at" in str(exc_info.value)
-    assert str(rms_project_path) in str(exc_info.value)
+    assert str(exc_info.value) == (
+        "RMS version cannot be determined because the RMS project "
+        f".master file is not found at {rms_project_path}."
+    )
 
 
 def test_get_rms_version_unsupported_version(rms_service: RmsService) -> None:

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -2745,17 +2745,21 @@ async def test_patch_rms_path_not_found(
 ) -> None:
     """Test 404 returns when RMS path does not exist."""
     rms_path = session_tmp_path / "missing_project.rms14.2.2"
+    error_message = (
+        "RMS version cannot be determined because the RMS project "
+        f".master file is not found at {rms_path}."
+    )
 
     with patch(
         "fmu_settings_api.services.rms.RmsService.get_rms_version",
-        side_effect=FileNotFoundError("master file not found"),
+        side_effect=FileNotFoundError(error_message),
     ):
         response = client_with_project_session.patch(
             f"{ROUTE}/rms",
             json={"path": str(rms_path)},
         )
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json() == {"detail": "master file not found"}
+    assert response.json() == {"detail": error_message}
 
 
 async def test_patch_rms_unsupported_version(

--- a/tests/test_v1/test_rms.py
+++ b/tests/test_v1/test_rms.py
@@ -208,7 +208,10 @@ async def test_open_rms_project_master_file_not_found(
     """Test opening an RMS project when its .master file does not exist."""
     mock_service = MagicMock()
     rms_path = Path("/path/to/rms/project")
-    error_message = f"RMS project .master file not found at '{rms_path}'."
+    error_message = (
+        "RMS version cannot be determined because the RMS project "
+        f".master file is not found at {rms_path}."
+    )
     mock_service.get_rms_version.side_effect = FileNotFoundError(error_message)
 
     app.dependency_overrides[get_rms_service] = lambda: mock_service


### PR DESCRIPTION
Resolves #396 

Improved RMS .master missing error message by adding the RMS version cannot be determined when .master file is missing.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
