### PR TITLE
ENH: Add Black Pearl to sumo_assets.json

### DIFF
--- a/src/fmu_settings_api/interfaces/sumo_assets.json
+++ b/src/fmu_settings_api/interfaces/sumo_assets.json
@@ -178,5 +178,10 @@
         "name": "Peon",
         "code": "036",
         "roleprefix": "PEON"
+    },
+    {
+        "name": "Black Pearl",
+        "code": "037",
+        "roleprefix": "BLACK-PEARL"
     }
 ]


### PR DESCRIPTION
This PR adds Black Pearl to the list of assets recognized by fmu-settings.
