### PR TITLE
ENH: Add Corvus to sumo_assets.json

### DIFF
--- a/src/fmu_settings_api/interfaces/sumo_assets.json
+++ b/src/fmu_settings_api/interfaces/sumo_assets.json
@@ -183,5 +183,10 @@
         "name": "Black Pearl",
         "code": "037",
         "roleprefix": "BLACK-PEARL"
+    },
+    {
+        "name": "Corvus",
+        "code": "038",
+        "roleprefix": "CORVUS"
     }
 ]


### PR DESCRIPTION
This PR adds Corvus to the list of assets recognized by fmu-settings.