### PR TITLE
CI: Speed up exception logging in tests

### DIFF
--- a/src/fmu_settings_api/logging.py
+++ b/src/fmu_settings_api/logging.py
@@ -90,7 +90,10 @@ def setup_logging(
         ]
     else:
         processors += [
-            structlog.dev.ConsoleRenderer(colors=True),
+            structlog.dev.ConsoleRenderer(
+                colors=True,
+                exception_formatter=structlog.dev.plain_traceback,
+            ),
         ]
 
     structlog.configure(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncGenerator, Callable, Generator, Iterator
 from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 from typing import Any, Literal
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -24,10 +24,12 @@ from fmu.settings import (
     init_fmu_directory,
     init_user_fmu_directory,
 )
+from fmu.settings.models.event_info import EventInfo
 from pytest import MonkeyPatch
 
 from fmu_settings_api.__main__ import app
 from fmu_settings_api.config import settings
+from fmu_settings_api.logging import setup_logging
 from fmu_settings_api.models.smda import StratigraphicUnit
 from fmu_settings_api.session import (
     SessionManager,
@@ -35,6 +37,13 @@ from fmu_settings_api.session import (
     create_fmu_session,
     get_fmu_session,
 )
+
+
+@pytest.fixture(autouse=True)
+def configure_test_logging() -> Generator[None]:
+    """Configure tests with the same logging setup path as the app."""
+    setup_logging(settings, Mock(spec_set=["add_log_entry"]), EventInfo)
+    yield
 
 
 @pytest.fixture


### PR DESCRIPTION
Resolves #417

Switch console exception logging to plain tracebacks so FastAPI 0.137+ router tracebacks do not make Rich render huge local variables. Tests now configure logging through the normal `setup_logging()` path with a strict mocked log manager, so direct `app` imports in pytest use the same console traceback behavior.

This keeps regular structlog console logs unchanged, but stops Rich from trying to render huge traceback locals for exception logs, which was what made the exception tests so slow in CI.

CI time:
Before this PR: 28m 54s (https://github.com/equinor/fmu-settings-api/actions/runs/28376766579)
After this PR: 42s (https://github.com/equinor/fmu-settings-api/actions/runs/28385731444)

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅