### PR TITLE
MAINT: Avoid storing RMS eclipse mappings on import

### DIFF
--- a/src/fmu_settings_api/services/mappings.py
+++ b/src/fmu_settings_api/services/mappings.py
@@ -81,12 +81,8 @@ class MappingsService:
         self: Self, relative_path: str | Path | None = None
     ) -> InternalWellboreMappings:
         """Import RMS-to-simulator wellbore mappings from an rms_eclipse CSV file."""
-        self._fmu_dir._lock.ensure_can_write()
-        wellbore_mappings = self._wellbore_mappings_file_io.read_rms_eclipse_csv(
+        return self._wellbore_mappings_file_io.read_rms_eclipse_csv(
             relative_path or self.RMS_ECLIPSE_CSV_PATH
-        )
-        return self._fmu_dir.mappings.update_internal_wellbore_mappings(
-            wellbore_mappings
         )
 
     def export_rms_simulator_csv(

--- a/tests/test_services/test_mappings_service.py
+++ b/tests/test_services/test_mappings_service.py
@@ -504,35 +504,25 @@ def test_resolve_internal_mapping_implementation_rejects_unsupported_type(
         )
 
 
-def test_import_rms_eclipse_csv_updates_wellbore_mappings(
+def test_import_rms_eclipse_csv_returns_wellbore_mappings(
     mappings_service: MappingsService,
-    fmu_dir: ProjectFMUDirectory,
     make_rms_simulator_mappings: Callable[[], InternalWellboreMappings],
 ) -> None:
-    """Test importing delegates to file IO and persists the returned mappings."""
+    """Test importing returns mappings read from the CSV file."""
     csv_relative_path = Path("data/custom/rms_eclipse.csv")
     imported_mappings = make_rms_simulator_mappings()
-    stored_mappings = InternalWellboreMappings(root=list(imported_mappings.root))
 
-    with (
-        patch.object(
-            mappings_service._wellbore_mappings_file_io,
-            "read_rms_eclipse_csv",
-            return_value=imported_mappings,
-        ) as read_mock,
-        patch.object(
-            fmu_dir.mappings,
-            "update_internal_wellbore_mappings",
-            return_value=stored_mappings,
-        ) as update_mock,
-    ):
+    with patch.object(
+        mappings_service._wellbore_mappings_file_io,
+        "read_rms_eclipse_csv",
+        return_value=imported_mappings,
+    ) as read_mock:
         assert (
             mappings_service.import_rms_eclipse_csv(csv_relative_path)
-            == stored_mappings
+            == imported_mappings
         )
 
     read_mock.assert_called_once_with(csv_relative_path)
-    update_mock.assert_called_once_with(imported_mappings)
 
 
 def test_export_rms_simulator_csv_forwards_filtered_mappings_and_path(


### PR DESCRIPTION
Resolves #413 

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
