### PR TITLE
ENH: Add Kalundborg to sumo_assets.json

### DIFF
--- a/src/fmu_settings_api/interfaces/sumo_assets.json
+++ b/src/fmu_settings_api/interfaces/sumo_assets.json
@@ -193,5 +193,10 @@
         "name": "Code",
         "code": "039",
         "roleprefix": "CODE"
+    },
+    {
+        "name": "Kalundborg",
+        "code": "040",
+        "roleprefix": "KALUNDBORG"
     }
 ]


### PR DESCRIPTION
This PR adds Kalundborg to the list of assets recognized by fmu-settings.