### PR TITLE
ENH: Add import export endpoints of mapping files

### DIFF
--- a/src/fmu_settings_api/models/project.py
+++ b/src/fmu_settings_api/models/project.py
@@ -34,13 +34,13 @@ class GlobalConfigPath(BaseResponseModel):
     """Relative path in the project to a global config file."""
 
 
-class MappingFilePath(BaseResponseModel):
-    """A path to a mappings import or export file, relative to the project root."""
+class RmsSimulatorMappingFilePath(BaseResponseModel):
+    """A path to an RMS-to-simulator mapping import or export file."""
 
     relative_path: Path = Field(
         examples=["rms/input/well_modelling/well_info/rms_eclipse.csv"]
     )
-    """Path to a mappings import or export file, relative to the project root."""
+    """Relative path in the project to an RMS-to-simulator mapping file."""
 
 
 class CacheRetention(BaseResponseModel):

--- a/src/fmu_settings_api/models/project.py
+++ b/src/fmu_settings_api/models/project.py
@@ -34,6 +34,15 @@ class GlobalConfigPath(BaseResponseModel):
     """Relative path in the project to a global config file."""
 
 
+class MappingFilePath(BaseResponseModel):
+    """A path to a mappings import or export file, relative to the project root."""
+
+    relative_path: Path = Field(
+        examples=["rms/input/well_modelling/well_info/rms_eclipse.csv"]
+    )
+    """Path to a mappings import or export file, relative to the project root."""
+
+
 class CacheRetention(BaseResponseModel):
     """Cache retention setting for project resources."""
 

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -59,8 +59,8 @@ from fmu_settings_api.models.project import (
     CacheRetention,
     GlobalConfigPath,
     LockStatus,
-    MappingFilePath,
     MasterdataSmdaMismatchDetail,
+    RmsSimulatorMappingFilePath,
     SumoAsset,
 )
 from fmu_settings_api.models.resource import CacheContent, CacheList
@@ -308,7 +308,7 @@ MappingsResponses: Final[Responses] = {
     ),
     **inline_add_response(
         404,
-        "Project mappings could not be processed because the project path was missing",
+        "Project mappings could not be updated because the project path was missing",
         [{"detail": "Project .fmu directory not found. It may have been deleted."}],
     ),
     **inline_add_response(
@@ -326,13 +326,53 @@ MappingsResponses: Final[Responses] = {
                     "invalid saved mappings."
                 )
             },
+            {"detail": "Invalid mappings: {error_message}"},
+        ],
+    ),
+}
+
+RmsSimulatorMappingsFileResponses: Final[Responses] = {
+    **inline_add_response(
+        403,
+        "The RMS-to-simulator wellbore mapping file could not be read or written",
+        [
+            {"detail": "Permission denied accessing .fmu at {path}"},
+            {"detail": "Permission denied while trying to export the mappings."},
+        ],
+    ),
+    **inline_add_response(
+        404,
+        "The RMS-to-simulator wellbore mapping file could not be found",
+        [
+            {"detail": "CSV file not found: '{path}'"},
+            {"detail": "Mappings file not found"},
+        ],
+    ),
+    **inline_add_response(
+        422,
+        dedent(
+            """
+            The RMS-to-simulator wellbore mapping file contains invalid content,
+            or no mappings can be exported.
+            """
+        ),
+        [
+            {"detail": "CSV file is missing required columns: {column_names}"},
+            {"detail": "CSV row has missing well mapping values at line {line_number}"},
+            {"detail": "Invalid mappings: {error_message}"},
+            {"detail": "Invalid mappings in existing file: {error_message}"},
             {
                 "detail": (
                     "Mappings were not exported because the project contains "
                     "invalid saved mappings."
                 )
             },
-            {"detail": "Invalid mappings: {error_message}"},
+            {
+                "detail": (
+                    "No rms-to-simulator primary wellbore mappings available to "
+                    "export as rms_simulator.renaming_table"
+                )
+            },
         ],
     ),
 }
@@ -1570,20 +1610,21 @@ async def put_mappings(
     description=dedent(
         """
         Reads an rms_eclipse.csv-format file from the project and returns the
-        imported RMS-to-simulator internal wellbore mappings. The path is relative
-        to the project root. If no path is provided, the default path relative to
-        the project root is rms/input/well_modelling/well_info/rms_eclipse.csv.
+        imported RMS-to-simulator mappings in the internal wellbore mapping format.
+        The path is relative to the project root. If no path is provided, the default
+        path relative to the project root is
+        rms/input/well_modelling/well_info/rms_eclipse.csv.
         """
     ),
     responses={
         **GetSessionResponses,
         **ProjectResponses,
-        **MappingsResponses,
+        **RmsSimulatorMappingsFileResponses,
     },
 )
 async def post_mappings_import_rms_eclipse_csv(
     mappings_service: MappingsServiceDep,
-    path: MappingFilePath | None = None,
+    path: RmsSimulatorMappingFilePath | None = None,
 ) -> InternalMappings:
     """Import RMS-to-simulator wellbore mappings from an rms_eclipse CSV file."""
     try:
@@ -1626,13 +1667,13 @@ async def post_mappings_import_rms_eclipse_csv(
     responses={
         **GetSessionResponses,
         **ProjectResponses,
-        **MappingsResponses,
+        **RmsSimulatorMappingsFileResponses,
         **LockConflictResponses,
     },
 )
 async def post_mappings_export_rms_simulator_renaming_table(
     mappings_service: MappingsServiceDep,
-    path: MappingFilePath | None = None,
+    path: RmsSimulatorMappingFilePath | None = None,
 ) -> Message:
     """Export RMS-to-simulator wellbore mappings to a renaming table file."""
     try:

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -59,6 +59,7 @@ from fmu_settings_api.models.project import (
     CacheRetention,
     GlobalConfigPath,
     LockStatus,
+    MappingFilePath,
     MasterdataSmdaMismatchDetail,
     SumoAsset,
 )
@@ -307,7 +308,7 @@ MappingsResponses: Final[Responses] = {
     ),
     **inline_add_response(
         404,
-        "Project mappings could not be updated because the project path was missing",
+        "Project mappings could not be processed because the project path was missing",
         [{"detail": "Project .fmu directory not found. It may have been deleted."}],
     ),
     **inline_add_response(
@@ -322,6 +323,12 @@ MappingsResponses: Final[Responses] = {
             {
                 "detail": (
                     "Mappings were not updated because the project contains "
+                    "invalid saved mappings."
+                )
+            },
+            {
+                "detail": (
+                    "Mappings were not exported because the project contains "
                     "invalid saved mappings."
                 )
             },
@@ -1554,6 +1561,121 @@ async def put_mappings(
                 ),
             ) from e
         raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post(
+    "/mappings/import/rms_eclipse_csv",
+    response_model=InternalMappings,
+    summary="Imports RMS-to-simulator wellbore mappings from rms_eclipse.csv.",
+    description=dedent(
+        """
+        Reads an rms_eclipse.csv-format file from the project and returns the
+        imported RMS-to-simulator internal wellbore mappings. The path is relative
+        to the project root. If no path is provided, the default path relative to
+        the project root is rms/input/well_modelling/well_info/rms_eclipse.csv.
+        """
+    ),
+    responses={
+        **GetSessionResponses,
+        **ProjectResponses,
+        **MappingsResponses,
+    },
+)
+async def post_mappings_import_rms_eclipse_csv(
+    mappings_service: MappingsServiceDep,
+    path: MappingFilePath | None = None,
+) -> InternalMappings:
+    """Import RMS-to-simulator wellbore mappings from an rms_eclipse CSV file."""
+    try:
+        wellbore_mappings = mappings_service.import_rms_eclipse_csv(
+            path.relative_path if path else None
+        )
+        return InternalMappings(wellbore=wellbore_mappings)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except PermissionError as e:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"Permission denied accessing .fmu at {mappings_service.fmu_dir_path}"
+            ),
+        ) from e
+    except ValidationError as e:
+        errors = [error.get("msg", str(error)) for error in e.errors()]
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid mappings: {'; '.join(errors)}",
+        ) from e
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+
+@router.post(
+    "/mappings/export/rms_simulator_renaming_table",
+    response_model=Message,
+    dependencies=[WritePermissionDep, RefreshLockDep],
+    summary="Exports RMS-to-simulator wellbore mappings to a renaming table.",
+    description=dedent(
+        """
+        Reads RMS-to-simulator wellbore mappings from mappings.json and writes them
+        to an rms_simulator renaming-table file. The path is relative to the project
+        root. If no path is provided, the default path relative to the project root is
+        rms/input/well_modelling/well_info/rms_simulator.renaming_table.
+        """
+    ),
+    responses={
+        **GetSessionResponses,
+        **ProjectResponses,
+        **MappingsResponses,
+        **LockConflictResponses,
+    },
+)
+async def post_mappings_export_rms_simulator_renaming_table(
+    mappings_service: MappingsServiceDep,
+    path: MappingFilePath | None = None,
+) -> Message:
+    """Export RMS-to-simulator wellbore mappings to a renaming table file."""
+    try:
+        relative_path = (
+            path.relative_path
+            if path
+            else mappings_service.RMS_SIMULATOR_RENAMING_TABLE_PATH
+        )
+        mappings_service.export_rms_simulator_renaming_table(relative_path)
+        return Message(
+            message=(
+                "Exported RMS-to-simulator mappings to renaming table at "
+                f"{relative_path}"
+            )
+        )
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except PermissionError as e:
+        raise HTTPException(
+            status_code=403,
+            detail="Permission denied while trying to export the mappings.",
+        ) from e
+    except ValidationError as e:
+        errors = [error.get("msg", str(error)) for error in e.errors()]
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid mappings in existing file: {'; '.join(errors)}",
+        ) from e
+    except ValueError as e:
+        if str(e).startswith(
+            (
+                "Invalid content in resource file for 'MappingsManager:",
+                "Invalid JSON in resource file for 'MappingsManager':",
+            )
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "Mappings were not exported because the project contains "
+                    "invalid saved mappings."
+                ),
+            ) from e
+        raise HTTPException(status_code=422, detail=str(e)) from e
 
 
 @router.get(

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -3609,6 +3609,294 @@ async def test_put_mappings_stratigraphy_invalid_existing_file_json_error(
     }
 
 
+# POST project/mappings/import/rms_eclipse_csv #
+
+
+async def test_post_import_rms_eclipse_csv_mappings_success(
+    client_with_project_session: TestClient,
+    make_rms_simulator_mappings: Callable[[], InternalWellboreMappings],
+) -> None:
+    """Test importing wellbore mappings returns the mappings model."""
+    wellbore_mappings = make_rms_simulator_mappings()
+    service_response = InternalMappings(wellbore=wellbore_mappings)
+    relative_path = Path("data/custom/rms_eclipse.csv")
+
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService.import_rms_eclipse_csv",
+        return_value=wellbore_mappings,
+    ) as import_rms_eclipse_csv:
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/import/rms_eclipse_csv",
+            json={"relative_path": str(relative_path)},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == service_response.model_dump(mode="json")
+    import_rms_eclipse_csv.assert_called_once_with(relative_path)
+
+
+async def test_post_import_rms_eclipse_csv_mappings_uses_default_path(
+    client_with_project_session: TestClient,
+    make_rms_simulator_mappings: Callable[[], InternalWellboreMappings],
+) -> None:
+    """Test importing without a request body uses the service default path."""
+    wellbore_mappings = make_rms_simulator_mappings()
+
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService.import_rms_eclipse_csv",
+        return_value=wellbore_mappings,
+    ) as import_rms_eclipse_csv:
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/import/rms_eclipse_csv"
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    import_rms_eclipse_csv.assert_called_once_with(None)
+
+
+async def test_post_import_rms_eclipse_csv_mappings_file_not_found(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test 404 returns when the CSV file is not found."""
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService.import_rms_eclipse_csv",
+        side_effect=FileNotFoundError("CSV file not found"),
+    ):
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/import/rms_eclipse_csv"
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "CSV file not found"}
+
+
+async def test_post_import_rms_eclipse_csv_mappings_permission_error(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test 403 returns when permissions prevent importing mappings."""
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService.import_rms_eclipse_csv",
+        side_effect=PermissionError("Permission denied"),
+    ):
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/import/rms_eclipse_csv"
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json()["detail"].startswith("Permission denied accessing .fmu at ")
+
+
+async def test_post_import_rms_eclipse_csv_mappings_validation_error(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test 422 returns when imported mappings fail validation."""
+    try:
+        InternalStratigraphyIdentifierMapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.smda,
+            relation_type=InternalRelationType.primary,
+            source_id="",
+            target_id="VOLANTIS GP. Top",
+        )
+        raise AssertionError("Expected ValidationError")
+    except ValidationError as exc:
+        validation_error = exc
+
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService.import_rms_eclipse_csv",
+        side_effect=validation_error,
+    ):
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/import/rms_eclipse_csv"
+        )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert "Invalid mappings:" in response.json()["detail"]
+
+
+async def test_post_import_rms_eclipse_csv_mappings_value_error(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test 422 returns when the CSV file cannot be imported."""
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService.import_rms_eclipse_csv",
+        side_effect=ValueError("CSV file is missing required columns: RMS_WELL_NAME"),
+    ):
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/import/rms_eclipse_csv"
+        )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert response.json() == {
+        "detail": "CSV file is missing required columns: RMS_WELL_NAME"
+    }
+
+
+# POST project/mappings/export/rms_simulator_renaming_table #
+
+
+async def test_post_export_rms_simulator_renaming_table_success(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test exporting RMS-to-simulator mappings calls the service."""
+    relative_path = Path("data/custom/rms_simulator.renaming_table")
+
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService."
+        "export_rms_simulator_renaming_table",
+    ) as export_rms_simulator_renaming_table:
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/export/rms_simulator_renaming_table",
+            json={"relative_path": str(relative_path)},
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "message": (
+            f"Exported RMS-to-simulator mappings to renaming table at {relative_path}"
+        )
+    }
+    export_rms_simulator_renaming_table.assert_called_once_with(relative_path)
+
+
+async def test_post_export_rms_simulator_renaming_table_uses_default_path(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test exporting without a request body uses the service default path."""
+    default_path = Path(
+        "rms/input/well_modelling/well_info/rms_simulator.renaming_table"
+    )
+
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService."
+        "export_rms_simulator_renaming_table",
+    ) as export_rms_simulator_renaming_table:
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/export/rms_simulator_renaming_table"
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "message": (
+            f"Exported RMS-to-simulator mappings to renaming table at {default_path}"
+        )
+    }
+    export_rms_simulator_renaming_table.assert_called_once_with(default_path)
+
+
+async def test_post_export_rms_simulator_renaming_table_file_not_found(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test 404 returns when exporting cannot find the project mappings."""
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService."
+        "export_rms_simulator_renaming_table",
+        side_effect=FileNotFoundError("Mappings file not found"),
+    ):
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/export/rms_simulator_renaming_table"
+        )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "Mappings file not found"}
+
+
+async def test_post_export_rms_simulator_renaming_table_permission_error(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test 403 returns when permissions prevent exporting mappings."""
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService."
+        "export_rms_simulator_renaming_table",
+        side_effect=PermissionError("Permission denied"),
+    ):
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/export/rms_simulator_renaming_table"
+        )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {
+        "detail": "Permission denied while trying to export the mappings."
+    }
+
+
+async def test_post_export_rms_simulator_renaming_table_validation_error(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test 422 returns when stored mappings fail validation."""
+    try:
+        InternalStratigraphyIdentifierMapping(
+            source_system=DataSystem.rms,
+            target_system=DataSystem.smda,
+            relation_type=InternalRelationType.primary,
+            source_id="",
+            target_id="VOLANTIS GP. Top",
+        )
+        raise AssertionError("Expected ValidationError")
+    except ValidationError as exc:
+        validation_error = exc
+
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService."
+        "export_rms_simulator_renaming_table",
+        side_effect=validation_error,
+    ):
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/export/rms_simulator_renaming_table"
+        )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert "Invalid mappings in existing file:" in response.json()["detail"]
+
+
+async def test_post_export_rms_simulator_renaming_table_invalid_existing_file(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test export hides parser details from invalid stored mappings."""
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService."
+        "export_rms_simulator_renaming_table",
+        side_effect=ValueError(
+            "Invalid JSON in resource file for 'MappingsManager': "
+            "'Expecting value: line 1 column 1 (char 0)'"
+        ),
+    ):
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/export/rms_simulator_renaming_table"
+        )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert response.json() == {
+        "detail": "Mappings were not exported because the project contains "
+        "invalid saved mappings."
+    }
+
+
+async def test_post_export_rms_simulator_renaming_table_value_error(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test 422 returns when no mappings can be exported."""
+    with patch(
+        "fmu_settings_api.services.mappings.MappingsService."
+        "export_rms_simulator_renaming_table",
+        side_effect=ValueError(
+            "No rms-to-simulator primary wellbore mappings available to export "
+            "as rms_simulator.renaming_table"
+        ),
+    ):
+        response = client_with_project_session.post(
+            f"{ROUTE}/mappings/export/rms_simulator_renaming_table"
+        )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert response.json() == {
+        "detail": (
+            "No rms-to-simulator primary wellbore mappings available to export "
+            "as rms_simulator.renaming_table"
+        )
+    }
+
+
 # GET project/cache #
 
 


### PR DESCRIPTION
Resolves #358 
Resolves #414 

Added two project mapping endpoints:

- `POST /project/mappings/import/rms_eclipse_csv`
- `POST /project/mappings/export/rms_simulator_renaming_table`

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅