### PR TITLE
MAINT: Better SMDA wellbore name for Drogon wells

### DIFF
--- a/src/fmu_settings_api/services/smda.py
+++ b/src/fmu_settings_api/services/smda.py
@@ -38,8 +38,8 @@ from fmu_settings_api.models.smda import (
 logger = get_logger(__name__)
 
 
-def _smda_wellbore_name(rms_well_name: str) -> str:
-    """Convert an RMS well name to an SMDA-style wellbore name."""
+def _drogon_wellbore_identifier(rms_well_name: str) -> str:
+    """Convert a Drogon RMS well name to an SMDA-style wellbore identifier."""
     name = re.sub(r"(?<=\d)_(?=\d)", "/", rms_well_name, count=1)
     return f"NO {name.replace('_', ' ')}"
 
@@ -82,8 +82,8 @@ DROGON_STRATIGRAPHIC_UNITS: Final[list[StratigraphicUnit]] = [
 ]
 DROGON_WELL_HEADERS: Final[list[SmdaWellHeader]] = [
     SmdaWellHeader(
-        unique_well_identifier=_smda_wellbore_name(str(well["name"])),
-        unique_wellbore_identifier=_smda_wellbore_name(str(well["name"])),
+        unique_well_identifier=_drogon_wellbore_identifier(str(well["name"])),
+        unique_wellbore_identifier=_drogon_wellbore_identifier(str(well["name"])),
         official_wellbore_name=str(well["name"]),
         country_identifier=DROGON_SMDA_MASTERDATA["country"][0]["identifier"],
         parent_wellbore=None,

--- a/src/fmu_settings_api/services/smda.py
+++ b/src/fmu_settings_api/services/smda.py
@@ -1,6 +1,7 @@
 """Service for querying and translating results from SMDA."""
 
 import asyncio
+import re
 from collections.abc import Sequence
 from typing import Any, Final
 from uuid import NAMESPACE_URL, uuid5
@@ -35,6 +36,13 @@ from fmu_settings_api.models.smda import (
 )
 
 logger = get_logger(__name__)
+
+
+def _smda_wellbore_name(rms_well_name: str) -> str:
+    """Convert an RMS well name to an SMDA-style wellbore name."""
+    name = re.sub(r"(?<=\d)_(?=\d)", "/", rms_well_name, count=1)
+    return f"NO {name.replace('_', ' ')}"
+
 
 DROGON_SMDA_MASTERDATA: Final[dict[str, Any]] = DROGON_MASTERDATA["smda"]
 DROGON_FIELD: Final[dict[str, Any]] = DROGON_SMDA_MASTERDATA["field"][0]
@@ -74,8 +82,8 @@ DROGON_STRATIGRAPHIC_UNITS: Final[list[StratigraphicUnit]] = [
 ]
 DROGON_WELL_HEADERS: Final[list[SmdaWellHeader]] = [
     SmdaWellHeader(
-        unique_well_identifier=f"NO {well['name']}",
-        unique_wellbore_identifier=f"NO {well['name']}",
+        unique_well_identifier=_smda_wellbore_name(str(well["name"])),
+        unique_wellbore_identifier=_smda_wellbore_name(str(well["name"])),
         official_wellbore_name=str(well["name"]),
         country_identifier=DROGON_SMDA_MASTERDATA["country"][0]["identifier"],
         parent_wellbore=None,

--- a/tests/test_services/test_smda_service.py
+++ b/tests/test_services/test_smda_service.py
@@ -168,11 +168,15 @@ async def test_get_drogon_well_headers_uses_drogon_data() -> None:
     assert [header.official_wellbore_name for header in res.well_headers] == [
         well["name"] for well in DROGON_RMS_WELLS
     ]
-    assert [header.unique_well_identifier for header in res.well_headers] == [
-        f"NO {well['name']}" for well in DROGON_RMS_WELLS
-    ]
+    identifiers_by_name = {
+        header.official_wellbore_name: header.unique_well_identifier
+        for header in res.well_headers
+    }
+    assert identifiers_by_name["55_33-A-1"] == "NO 55/33-A-1"
+    assert identifiers_by_name["OP5_Y1"] == "NO OP5 Y1"
+    assert identifiers_by_name["RFT_55_33-A-2"] == "NO RFT 55/33-A-2"
     assert [header.unique_wellbore_identifier for header in res.well_headers] == [
-        f"NO {well['name']}" for well in DROGON_RMS_WELLS
+        header.unique_well_identifier for header in res.well_headers
     ]
     assert res.well_headers[0].country_identifier == "Norway"
     assert res.well_headers[0].projected_coordinate_system == "ST_WGS84_UTM37N_P32637"


### PR DESCRIPTION
Resolves #431

Changed the SMDA wellbore names for Drogon wells to be more like SMDA names, from "NO 55_33-A-1" to "NO 55/33-A-1"

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
