### PR TITLE
ENH: Serve packaged frontend from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fmu settings api --print-token --reload
 ## API Documentation
 
 The routes have documentation on them. To view them, and work with the API go
-to `localhost:8001/docs` (or whatever your port may end up being).
+to `localhost:8000/docs` (or whatever your port may end up being).
 
 ## Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "fastapi",
+    "fastapi>=0.138.0",  # FastAPI.frontend() support
     "fmu-datamodels>=0.21.4",  # no equivalent relation, no fmu data system
     "fmu-settings>=1.0.0",  # validation metadata in project config
     "httpx2",
@@ -140,4 +140,3 @@ exclude-newer = "1 week"
 "fmu-datamodels" = false
 "fmu-settings" = false
 "runrms" = false
-

--- a/src/fmu_settings_api/__main__.py
+++ b/src/fmu_settings_api/__main__.py
@@ -5,6 +5,7 @@ import sys
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
+from pathlib import Path
 
 import uvicorn
 from fastapi import FastAPI
@@ -149,6 +150,11 @@ async def health_check() -> Ok:
     return Ok()
 
 
+def add_frontend(frontend_app: FastAPI, directory: Path) -> None:
+    """Serve a built single-page application from a FastAPI application."""
+    frontend_app.frontend("/", directory=directory, fallback="index.html")
+
+
 def run_server(  # noqa: PLR0913
     *,
     host: str = "127.0.0.1",
@@ -158,8 +164,9 @@ def run_server(  # noqa: PLR0913
     token: str | None = None,
     reload: bool = False,
     log_level: str = "critical",
+    frontend_directory: Path | None = None,
 ) -> None:
-    """Starts the API server."""
+    """Start the API server and, when supplied, its built frontend."""
     log_level = log_level.lower()
 
     try:
@@ -194,6 +201,9 @@ def run_server(  # noqa: PLR0913
             allow_headers=["*"],
             expose_headers=[HttpHeader.UPSTREAM_SOURCE_KEY],
         )
+
+    if frontend_directory is not None:
+        add_frontend(app, frontend_directory)
 
     if reload:
         uvicorn.run(

--- a/src/fmu_settings_api/__main__.py
+++ b/src/fmu_settings_api/__main__.py
@@ -158,7 +158,7 @@ def add_frontend(frontend_app: FastAPI, directory: Path) -> None:
 def run_server(  # noqa: PLR0913
     *,
     host: str = "127.0.0.1",
-    port: int = 8001,
+    port: int = 8000,
     frontend_host: str | None = None,
     frontend_port: int | None = None,
     token: str | None = None,

--- a/src/fmu_settings_api/__main__.py
+++ b/src/fmu_settings_api/__main__.py
@@ -152,7 +152,7 @@ async def health_check() -> Ok:
 
 def add_frontend(frontend_app: FastAPI, directory: Path) -> None:
     """Serve a built single-page application from a FastAPI application."""
-    frontend_app.frontend("/", directory=directory, fallback="index.html")
+    frontend_app.frontend("/", directory=directory)
 
 
 def run_server(  # noqa: PLR0913

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 """Tests for the __main__ module."""
 
 from datetime import UTC, datetime
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -11,9 +12,11 @@ from fastapi.testclient import TestClient
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from fmu_settings_api.__main__ import (
+    add_frontend,
     app,
     logging_http_exception_handler,
     logging_request_validation_exception_handler,
+    run_server,
 )
 from fmu_settings_api.middleware.logging import LoggingMiddleware
 from fmu_settings_api.models import Ok
@@ -37,6 +40,52 @@ def test_health_check() -> None:
     assert response.status_code == status.HTTP_200_OK, response.json()
     assert response.json() == {"status": "ok"}
     assert Ok() == Ok.model_validate(response.json())
+
+
+def test_add_frontend_serves_spa_without_hiding_api_routes(tmp_path: Path) -> None:
+    """Serve frontend files and keep explicit API routes at higher priority."""
+    frontend_directory = tmp_path / "static"
+    assets_directory = frontend_directory / "assets"
+    assets_directory.mkdir(parents=True)
+    (frontend_directory / "index.html").write_text(
+        "<html>frontend</html>", encoding="utf-8"
+    )
+    (assets_directory / "app.js").write_text("app", encoding="utf-8")
+
+    test_app = FastAPI()
+
+    @test_app.get("/api/value")
+    async def get_value() -> dict[str, str]:
+        return {"value": "api"}
+
+    add_frontend(test_app, frontend_directory)
+    local_client = TestClient(test_app)
+
+    api_response = local_client.get("/api/value")
+    route_response = local_client.get(
+        "/project/masterdata", headers={"accept": "text/html"}
+    )
+    asset_response = local_client.get("/assets/app.js")
+
+    assert api_response.json() == {"value": "api"}
+    assert route_response.text == "<html>frontend</html>"
+    assert asset_response.text == "app"
+
+
+def test_run_server_adds_frontend(tmp_path: Path) -> None:
+    """Add the frontend when its directory is supplied."""
+    with (
+        patch("fmu_settings_api.__main__.UserFMUDirectory") as user_directory,
+        patch("fmu_settings_api.__main__.UserSessionLogManager"),
+        patch("fmu_settings_api.__main__.setup_logging"),
+        patch("fmu_settings_api.__main__.uvicorn.run"),
+        patch("fmu_settings_api.__main__.app") as test_app,
+        patch("fmu_settings_api.__main__.add_frontend") as add_frontend_mock,
+    ):
+        user_directory.return_value.path = tmp_path
+        run_server(frontend_directory=tmp_path, reload=True)
+
+    add_frontend_mock.assert_called_once_with(test_app, tmp_path)
 
 
 def test_shutdown_releases_project_lock() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -78,7 +78,7 @@ def test_run_server_adds_frontend(tmp_path: Path) -> None:
         patch("fmu_settings_api.__main__.UserFMUDirectory") as user_directory,
         patch("fmu_settings_api.__main__.UserSessionLogManager"),
         patch("fmu_settings_api.__main__.setup_logging"),
-        patch("fmu_settings_api.__main__.uvicorn.run"),
+        patch("fmu_settings_api.__main__.uvicorn.run") as uvicorn_run,
         patch("fmu_settings_api.__main__.app") as test_app,
         patch("fmu_settings_api.__main__.add_frontend") as add_frontend_mock,
     ):
@@ -86,6 +86,7 @@ def test_run_server_adds_frontend(tmp_path: Path) -> None:
         run_server(frontend_directory=tmp_path, reload=True)
 
     add_frontend_mock.assert_called_once_with(test_app, tmp_path)
+    assert uvicorn_run.call_args.kwargs["port"] == 8000
 
 
 def test_shutdown_releases_project_lock() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -378,7 +378,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi" },
+    { name = "fastapi", specifier = ">=0.138.0" },
     { name = "fmu-datamodels", specifier = ">=0.21.4" },
     { name = "fmu-settings", specifier = ">=1.0.0" },
     { name = "fmu-settings-cli", marker = "extra == 'dev'" },


### PR DESCRIPTION
Part of #433

Added an optional frontend directory to `run_server()`. When supplied, FastAPI serves the packaged React application from `/` with SPA fallback support to `index.html`.

API routes keep priority over frontend routes, and `fmu settings api` can still run without a frontend. FastAPI 0.138 or newer is required for `FastAPI.frontend()`.

## Review order

This PR and [fmu-settings-gui#492](https://github.com/equinor/fmu-settings-gui/pull/492) can be reviewed in parallel. They define the interfaces used by the CLI.

Both should be merged and released before the CLI PR is finalized. The optional `fmu-settings` documentation PR can be reviewed last.

## Checklist

- [x] Tests added
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅