### PR TITLE
ENH: Support field UUIDs in well header lookup

### DIFF
--- a/src/fmu_settings_api/interfaces/smda_api.py
+++ b/src/fmu_settings_api/interfaces/smda_api.py
@@ -115,13 +115,23 @@ class SmdaAPI:
         )
 
     async def well_headers(
-        self, field_identifiers: Sequence[str], columns: Sequence[str] | None = None
+        self,
+        field_identifiers: Sequence[str] | None = None,
+        columns: Sequence[str] | None = None,
+        field_uuid: UUID | None = None,
     ) -> httpx2.Response:
-        """Searches for well headers related to a field identifier."""
+        """Searches for well headers related to a field."""
         _projection = "identifier,uuid" if columns is None else ",".join(columns)
+        json: dict[str, Any] = {"_projection": _projection}
+
+        if field_identifiers:
+            json["field_identifier"] = field_identifiers
+        if field_uuid is not None:
+            json["field_uuid"] = [str(field_uuid)]
+
         return await self.post(
             SmdaRoutes.WELL_HEADER_SEARCH,
-            json={"_projection": _projection, "field_identifier": field_identifiers},
+            json=json,
         )
 
     async def strat_column_areas(

--- a/src/fmu_settings_api/models/smda.py
+++ b/src/fmu_settings_api/models/smda.py
@@ -23,7 +23,7 @@ class SmdaField(BaseResponseModel):
 
 
 class SmdaSelectedField(BaseResponseModel):
-    """A selected field for masterdata lookup."""
+    """A selected SMDA field."""
 
     identifier: str = Field(examples=["TROLL"])
     """A field identifier (name)."""

--- a/src/fmu_settings_api/services/smda.py
+++ b/src/fmu_settings_api/services/smda.py
@@ -379,17 +379,18 @@ class SmdaService:
                 strat_unit_items.append(strat_unit_item)
         return SmdaStratigraphicUnitsResult(stratigraphic_units=strat_unit_items)
 
-    async def get_well_headers(self, field_identifier: str) -> SmdaWellHeadersResult:
-        """Queries well headers for a field identifier."""
-        if not field_identifier:
+    async def get_well_headers(self, field: SmdaSelectedField) -> SmdaWellHeadersResult:
+        """Queries well headers for a selected SMDA field."""
+        if not field.identifier:
             raise ValueError("A field identifier must be provided")
 
-        if _is_drogon_identifier(field_identifier):
+        if _is_drogon_identifier(field.identifier):
             return SmdaWellHeadersResult(well_headers=DROGON_WELL_HEADERS)
 
         well_header_items = []
         well_header_res = await self._smda.well_headers(
-            [field_identifier],
+            field_identifiers=None if field.uuid is not None else [field.identifier],
+            field_uuid=field.uuid,
             columns=[
                 "unique_well_identifier",
                 "unique_wellbore_identifier",
@@ -416,8 +417,10 @@ class SmdaService:
             if well_header_item not in well_header_items:
                 well_header_items.append(well_header_item)
         if not well_header_items:
+            if field.uuid is not None:
+                raise ValueError(f"No well headers found for field UUID: {field.uuid}")
             raise ValueError(
-                f"No well headers found for field identifier: {field_identifier}"
+                f"No well headers found for field identifier: {field.identifier}"
             )
         return SmdaWellHeadersResult(well_headers=well_header_items)
 

--- a/src/fmu_settings_api/v1/routes/smda/main.py
+++ b/src/fmu_settings_api/v1/routes/smda/main.py
@@ -58,6 +58,7 @@ SmdaUpstreamErrorResponses: Final[Responses] = {
             {"detail": "No fields found for identifiers: {identifiers}"},
             {"detail": "No stratigraphic units found for column: {identifier}"},
             {"detail": "No well headers found for field identifier: {identifier}"},
+            {"detail": "No well headers found for field UUID: {uuid}"},
         ],
     ),
     **inline_add_response(
@@ -354,8 +355,11 @@ async def post_strat_units(
         """
         A route to gather well header data from SMDA for a specified field.
 
-        This route receives a valid field identifier and returns the well header
-        fields needed to identify and map SMDA wellbores against model well names.
+        This route receives a selected SMDA field and returns the well header
+        attributes needed to identify and map SMDA wellbores against model well
+        names. When provided, the field UUID is used to find well headers for the
+        selected SMDA field. If no field UUID is provided, the field identifier is
+        used instead.
         """
     ),
     responses={
@@ -364,12 +368,12 @@ async def post_strat_units(
     },
 )
 async def post_well_headers(
-    field: SmdaField,
+    field: SmdaSelectedField,
     smda_service: ProjectSmdaServiceDep,
 ) -> SmdaWellHeadersResult:
-    """Queries SMDA well headers for a specified field."""
+    """Queries SMDA well headers for a specified SMDA field."""
     try:
-        return await smda_service.get_well_headers(field.identifier)
+        return await smda_service.get_well_headers(field)
     except ValueError as e:
         error_msg = str(e)
         match error_msg:

--- a/tests/test_interfaces/test_smda_api.py
+++ b/tests/test_interfaces/test_smda_api.py
@@ -332,3 +332,23 @@ async def test_smda_well_header_search_with_columns(
         },
     )
     res.raise_for_status.assert_called_once()  # type: ignore
+
+
+async def test_smda_well_header_search_with_uuid(
+    mock_httpx_post: MagicMock,
+) -> None:
+    """Tests well header search can query using a field UUID."""
+    api = SmdaAPI("token", "key")
+    field_uuid = UUID("c8da9f15-f7d9-4d47-a2a3-60e34e9d15d7")
+
+    res = await api.well_headers(field_uuid=field_uuid)
+
+    mock_httpx_post.assert_called_with(
+        f"{SmdaRoutes.BASE_URL}/{SmdaRoutes.WELL_HEADER_SEARCH}",
+        headers=api._headers,
+        json={
+            "_projection": "identifier,uuid",
+            "field_uuid": ["c8da9f15-f7d9-4d47-a2a3-60e34e9d15d7"],
+        },
+    )
+    res.raise_for_status.assert_called_once()  # type: ignore

--- a/tests/test_services/test_smda_service.py
+++ b/tests/test_services/test_smda_service.py
@@ -98,10 +98,11 @@ async def test_get_well_headers_result() -> None:
     mock_smda.well_headers.return_value = well_header_resp
 
     service = SmdaService(mock_smda)
-    res = await service.get_well_headers("TROLL")
+    res = await service.get_well_headers(SmdaSelectedField(identifier="TROLL"))
 
     mock_smda.well_headers.assert_called_with(
-        ["TROLL"],
+        field_identifiers=["TROLL"],
+        field_uuid=None,
         columns=[
             "unique_well_identifier",
             "unique_wellbore_identifier",
@@ -136,7 +137,7 @@ async def test_get_well_headers_empty_identifier() -> None:
     service = SmdaService(mock_smda)
 
     with pytest.raises(ValueError, match="A field identifier must be provided"):
-        await service.get_well_headers("")
+        await service.get_well_headers(SmdaSelectedField(identifier=""))
 
     mock_smda.well_headers.assert_not_called()
 
@@ -154,7 +155,7 @@ async def test_get_well_headers_no_results() -> None:
         ValueError,
         match="No well headers found for field identifier: TROLL",
     ):
-        await service.get_well_headers("TROLL")
+        await service.get_well_headers(SmdaSelectedField(identifier="TROLL"))
 
 
 async def test_get_drogon_well_headers_uses_drogon_data() -> None:
@@ -162,7 +163,7 @@ async def test_get_drogon_well_headers_uses_drogon_data() -> None:
     mock_smda = AsyncMock()
     service = SmdaService(mock_smda)
 
-    res = await service.get_well_headers("Drogon")
+    res = await service.get_well_headers(SmdaSelectedField(identifier="Drogon"))
 
     mock_smda.well_headers.assert_not_called()
     assert [header.official_wellbore_name for header in res.well_headers] == [
@@ -190,6 +191,29 @@ async def test_get_drogon_well_headers_uses_drogon_data() -> None:
         if header.official_wellbore_name == "MLW_OP5_Y1"
     )
     assert multilateral_well.multilateral == 1
+
+
+async def test_get_well_headers_uses_selected_field_uuid() -> None:
+    """Tests that well header lookup uses the selected field UUID."""
+    mock_smda = AsyncMock()
+    field_uuid = uuid4()
+    well_header_resp = MagicMock()
+    well_header_resp.json.return_value = {"data": {"results": []}}
+    mock_smda.well_headers.return_value = well_header_resp
+
+    service = SmdaService(mock_smda)
+
+    with pytest.raises(
+        ValueError,
+        match=f"No well headers found for field UUID: {field_uuid}",
+    ):
+        await service.get_well_headers(
+            SmdaSelectedField(identifier="TROLL", uuid=field_uuid)
+        )
+
+    mock_smda.well_headers.assert_awaited_once()
+    assert mock_smda.well_headers.await_args.kwargs["field_identifiers"] is None
+    assert mock_smda.well_headers.await_args.kwargs["field_uuid"] == field_uuid
 
 
 @pytest.mark.parametrize(

--- a/tests/test_v1/test_smda.py
+++ b/tests/test_v1/test_smda.py
@@ -23,6 +23,7 @@ from fmu_settings_api.deps.smda import get_project_smda_service
 from fmu_settings_api.models.smda import (
     SmdaFieldSearchResult,
     SmdaFieldUUID,
+    SmdaSelectedField,
     SmdaWellHeadersResult,
 )
 
@@ -1267,7 +1268,8 @@ async def test_post_well_headers_success(
     client_with_smda_session: TestClient,
     session_tmp_path: Path,
 ) -> None:
-    """Tests successful post to well_headers with valid field identifier."""
+    """Tests successful post to well_headers with a selected field."""
+    field_uuid = uuid4()
     smda_service = MagicMock()
     smda_service.get_well_headers = AsyncMock(
         return_value=SmdaWellHeadersResult(well_headers=[])
@@ -1276,7 +1278,7 @@ async def test_post_well_headers_success(
 
     response = client_with_smda_session.post(
         f"{ROUTE}/well_headers",
-        json={"identifier": "TROLL"},
+        json={"identifier": "TROLL", "uuid": str(field_uuid)},
     )
 
     assert response.status_code == status.HTTP_200_OK, response.json()
@@ -1285,7 +1287,9 @@ async def test_post_well_headers_success(
         == HttpHeader.UPSTREAM_SOURCE_SMDA
     )
     assert response.json() == {"well_headers": []}
-    smda_service.get_well_headers.assert_awaited_once_with("TROLL")
+    smda_service.get_well_headers.assert_awaited_once_with(
+        SmdaSelectedField(identifier="TROLL", uuid=field_uuid)
+    )
 
 
 async def test_post_well_headers_empty_results(
@@ -1312,7 +1316,9 @@ async def test_post_well_headers_empty_results(
         == HttpHeader.UPSTREAM_SOURCE_SMDA
     )
     assert "No well headers found" in response.json()["detail"]
-    smda_service.get_well_headers.assert_awaited_once_with("TROLL")
+    smda_service.get_well_headers.assert_awaited_once_with(
+        SmdaSelectedField(identifier="TROLL")
+    )
 
 
 async def test_post_well_headers_drogon_identifier_calls_service(
@@ -1332,7 +1338,9 @@ async def test_post_well_headers_drogon_identifier_calls_service(
     )
 
     assert response.status_code == status.HTTP_200_OK, response.json()
-    smda_service.get_well_headers.assert_awaited_once_with("Drogon")
+    smda_service.get_well_headers.assert_awaited_once_with(
+        SmdaSelectedField(identifier="Drogon")
+    )
 
 
 async def test_post_well_headers_empty_identifier(
@@ -1357,7 +1365,9 @@ async def test_post_well_headers_empty_identifier(
         == HttpHeader.UPSTREAM_SOURCE_SMDA
     )
     assert "must be provided" in response.json()["detail"]
-    smda_service.get_well_headers.assert_awaited_once_with("")
+    smda_service.get_well_headers.assert_awaited_once_with(
+        SmdaSelectedField(identifier="")
+    )
 
 
 async def test_post_well_headers_malformed_response(
@@ -1382,7 +1392,9 @@ async def test_post_well_headers_malformed_response(
         == HttpHeader.UPSTREAM_SOURCE_SMDA
     )
     assert "Malformed response from SMDA" in response.json()["detail"]
-    smda_service.get_well_headers.assert_awaited_once_with("TROLL")
+    smda_service.get_well_headers.assert_awaited_once_with(
+        SmdaSelectedField(identifier="TROLL")
+    )
 
 
 async def test_post_well_headers_request_timeout(
@@ -1407,7 +1419,9 @@ async def test_post_well_headers_request_timeout(
         == HttpHeader.UPSTREAM_SOURCE_SMDA
     )
     assert response.json()["detail"] == "SMDA API request timed out. Please try again."
-    smda_service.get_well_headers.assert_awaited_once_with("TROLL")
+    smda_service.get_well_headers.assert_awaited_once_with(
+        SmdaSelectedField(identifier="TROLL")
+    )
 
 
 async def test_post_well_headers_http_error(
@@ -1440,4 +1454,6 @@ async def test_post_well_headers_http_error(
         == HttpHeader.UPSTREAM_SOURCE_SMDA
     )
     assert "SMDA error requesting" in response.json()["detail"]
-    smda_service.get_well_headers.assert_awaited_once_with("TROLL")
+    smda_service.get_well_headers.assert_awaited_once_with(
+        SmdaSelectedField(identifier="TROLL")
+    )


### PR DESCRIPTION
Resolves #439

Adds field UUID support to `/api/v1/smda/well_headers` so the selected SMDA field is unique. Identifier lookup remains available when no field UUID is provided. I have tested this manually by sending Troll field uuid and it works.

This implementation is similar to https://github.com/equinor/fmu-settings-api/pull/345 where we add support for using field uuid to search for masterdata.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
