### PR TITLE
ENH: Return all SMDA well-headers results

### DIFF
--- a/src/fmu_settings_api/interfaces/smda_api.py
+++ b/src/fmu_settings_api/interfaces/smda_api.py
@@ -122,7 +122,7 @@ class SmdaAPI:
     ) -> httpx2.Response:
         """Searches for well headers related to a field."""
         _projection = "identifier,uuid" if columns is None else ",".join(columns)
-        json: dict[str, Any] = {"_projection": _projection}
+        json: dict[str, Any] = {"_projection": _projection, "_items": 9999}
 
         if field_identifiers:
             json["field_identifier"] = field_identifiers

--- a/tests/test_interfaces/test_smda_api.py
+++ b/tests/test_interfaces/test_smda_api.py
@@ -310,6 +310,7 @@ async def test_smda_well_header_search(mock_httpx_post: MagicMock) -> None:
         json={
             "_projection": "identifier,uuid",
             "field_identifier": ["FIELD_A"],
+            "_items": 9999,
         },
     )
     res.raise_for_status.assert_called_once()  # type: ignore
@@ -329,6 +330,7 @@ async def test_smda_well_header_search_with_columns(
         json={
             "_projection": "unique_well_identifier",
             "field_identifier": ["FIELD_A"],
+            "_items": 9999,
         },
     )
     res.raise_for_status.assert_called_once()  # type: ignore
@@ -349,6 +351,7 @@ async def test_smda_well_header_search_with_uuid(
         json={
             "_projection": "identifier,uuid",
             "field_uuid": ["c8da9f15-f7d9-4d47-a2a3-60e34e9d15d7"],
+            "_items": 9999,
         },
     )
     res.raise_for_status.assert_called_once()  # type: ignore


### PR DESCRIPTION
Resolves #444 

Now the automatic matching gets all the results from SMDA well headers. Exact match from that field I demo'ed got 922 exact matches.
<img width="668" height="115" alt="2026-08-03_10-13-15 AM" src="https://github.com/user-attachments/assets/cad4f822-3f13-45d4-88ba-b73ce4d8a98a" />

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
