### PR TITLE
ENH: Add RMS project config validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version"]
 dependencies = [
     "fastapi>=0.138.0",  # FastAPI.frontend() support
     "fmu-datamodels>=0.21.4",  # no equivalent relation, no fmu data system
-    "fmu-settings>=1.0.0",  # validation metadata in project config
+    "fmu-settings>=1.1.0",  # update_validation_metadata() method for project fmu_dir
     "httpx2",
     "packaging",
     "pydantic",

--- a/src/fmu_settings_api/deps/validation.py
+++ b/src/fmu_settings_api/deps/validation.py
@@ -5,19 +5,14 @@ from typing import Annotated
 from fastapi import Depends
 
 from fmu_settings_api.deps.session import ProjectSessionDep
-from fmu_settings_api.deps.smda import ProjectSmdaServiceDep
 from fmu_settings_api.services.project_validation import ProjectValidationService
 
 
 async def get_project_validation_service(
     project_session: ProjectSessionDep,
-    smda_service: ProjectSmdaServiceDep,
 ) -> ProjectValidationService:
     """Returns a ProjectValidationService instance."""
-    return ProjectValidationService(
-        project_session.project_fmu_directory,
-        smda_service,
-    )
+    return ProjectValidationService(project_session.project_fmu_directory)
 
 
 ProjectValidationServiceDep = Annotated[

--- a/src/fmu_settings_api/models/project.py
+++ b/src/fmu_settings_api/models/project.py
@@ -100,18 +100,18 @@ class ValidationMismatch(BaseResponseModel):
     saved_value: Any
     """The value currently saved in the project configuration."""
 
-    source_value: Any
-    """The value found in the validation source."""
+    source_value: Any | None
+    """The source value, or null when the saved item is not present."""
 
     message: str
     """Description of the mismatch."""
 
 
-class MasterdataSmdaMismatchDetail(BaseResponseModel):
-    """Details for project masterdata mismatches against SMDA."""
+class ValidationMismatchDetail(BaseResponseModel):
+    """Details for project validation mismatches."""
 
     message: str
     """Summary of the validation failure."""
 
     mismatches: list[ValidationMismatch]
-    """List of project masterdata values that do not match SMDA."""
+    """List of project values that do not match the validation source."""

--- a/src/fmu_settings_api/services/project.py
+++ b/src/fmu_settings_api/services/project.py
@@ -1,7 +1,5 @@
 """Service for managing FMU project operations and business logic."""
 
-import getpass
-from datetime import UTC, datetime
 from pathlib import Path
 
 from fmu.datamodels.common import Access, Smda
@@ -12,12 +10,15 @@ from fmu.settings.models.project_config import (
     RmsHorizon,
     RmsStratigraphicZone,
     RmsWell,
-    ValidationRecord,
 )
 
 from fmu_settings_api.interfaces import SumoApi
 from fmu_settings_api.models import FMUProject
-from fmu_settings_api.models.project import CacheRetention, GlobalConfigPath, SumoAsset
+from fmu_settings_api.models.project import (
+    CacheRetention,
+    GlobalConfigPath,
+    SumoAsset,
+)
 
 from .rms import RmsService
 
@@ -94,13 +95,7 @@ class ProjectService:
     def update_masterdata(self, smda_masterdata: Smda) -> None:
         """Save SMDA masterdata to the project FMU directory."""
         self._fmu_dir.set_config_value("masterdata.smda", smda_masterdata.model_dump())
-        record = ValidationRecord(
-            last_validated_at=datetime.now(UTC),
-            last_validated_by=getpass.getuser(),
-        )
-        self._fmu_dir.set_config_value(
-            "validation.masterdata_smda", record.model_dump()
-        )
+        self._fmu_dir.update_validation_metadata("masterdata_smda")
 
     def update_model(self, model: Model) -> None:
         """Save model data to the project FMU directory."""

--- a/src/fmu_settings_api/services/project_validation.py
+++ b/src/fmu_settings_api/services/project_validation.py
@@ -1,17 +1,22 @@
 """Service for validating project configuration against external sources."""
 
 import asyncio
-import getpass
 import json
-from datetime import UTC, datetime
+from collections.abc import Sequence
 
 from fmu.datamodels.common import Smda
 from fmu.settings import ProjectFMUDirectory
-from fmu.settings.models.project_config import ValidationRecord
+from fmu.settings.models.project_config import (
+    RmsHorizon,
+    RmsStratigraphicZone,
+    RmsWell,
+)
 from pydantic import BaseModel
+from runrms.api import RmsApiProxy
 
 from fmu_settings_api.models.project import ValidationMismatch
 from fmu_settings_api.models.smda import SmdaMasterdataResult, SmdaSelectedField
+from fmu_settings_api.services.rms import RmsService
 from fmu_settings_api.services.smda import SmdaService
 
 
@@ -23,15 +28,25 @@ class MasterdataSmdaMismatchError(ValueError):
         self.mismatches = mismatches
 
 
+class RmsProjectMismatchError(ValueError):
+    """Raised when saved RMS settings do not match the open RMS project."""
+
+    def __init__(self, mismatches: list[ValidationMismatch]) -> None:
+        """Initialize with validation mismatches."""
+        self.mismatches = mismatches
+
+
 class ProjectValidationService:
     """Service for validating project configuration."""
 
-    def __init__(self, fmu_dir: ProjectFMUDirectory, smda_service: SmdaService) -> None:
-        """Initialize the service with project and SMDA access."""
+    def __init__(self, fmu_dir: ProjectFMUDirectory) -> None:
+        """Initialize the service with project access."""
         self._fmu_dir = fmu_dir
-        self._smda_service = smda_service
 
-    async def validate_masterdata_smda(self) -> None:
+    async def validate_masterdata_smda(
+        self,
+        smda_service: SmdaService,
+    ) -> None:
         """Validate saved SMDA masterdata and update validation metadata.
 
         Flow:
@@ -57,7 +72,7 @@ class ProjectValidationService:
         ]
         per_field_smda_results = await asyncio.gather(
             *[
-                self._smda_service.get_masterdata([selected_field])
+                smda_service.get_masterdata([selected_field])
                 for selected_field in selected_fields
             ]
         )
@@ -138,10 +153,134 @@ class ProjectValidationService:
         if mismatches:
             raise MasterdataSmdaMismatchError(mismatches)
 
-        record = ValidationRecord(
-            last_validated_at=datetime.now(UTC),
-            last_validated_by=getpass.getuser(),
-        )
-        self._fmu_dir.set_config_value(
-            "validation.masterdata_smda", record.model_dump()
-        )
+        self._fmu_dir.update_validation_metadata("masterdata_smda")
+
+    def validate_rms_project(
+        self,
+        rms_service: RmsService,
+        opened_rms_project: RmsApiProxy,
+    ) -> None:
+        """Compare saved RMS settings with the open RMS project.
+
+        The check compares the saved RMS version, horizons, zones, and wells
+        with the open project. For wells, it checks every value except
+        ``planned``.
+
+        Every saved horizon, zone, and well must exist in the open project. The
+        order of these items does not matter.
+
+        An empty saved list is valid. It means the user saved no horizons, zones,
+        or wells, either by clearing the category or because the open RMS project
+        had none to save.
+
+        The coordinate system is not checked because it is not currently saved
+        in the project configuration.
+        """
+        config = self._fmu_dir.config.load()
+        if config.rms is None:
+            raise ValueError("No RMS settings are saved in the FMU project.")
+
+        saved_rms = config.rms
+        mismatches: list[ValidationMismatch] = []
+
+        current_version = rms_service.get_rms_version(saved_rms.path)
+        if saved_rms.version != current_version:
+            mismatches.append(
+                ValidationMismatch(
+                    key="rms.version",
+                    saved_value=saved_rms.version,
+                    source_value=current_version,
+                    message=(
+                        "The RMS version saved in the FMU project does not match "
+                        "the version of the open RMS project."
+                    ),
+                )
+            )
+
+        if saved_rms.horizons is not None:
+            mismatches.extend(
+                _find_rms_item_mismatches(
+                    key_prefix="rms.horizons",
+                    item_label="horizon",
+                    saved_items=saved_rms.horizons,
+                    source_items=rms_service.get_horizons(opened_rms_project),
+                )
+            )
+
+        if saved_rms.zones is not None:
+            mismatches.extend(
+                _find_rms_item_mismatches(
+                    key_prefix="rms.zones",
+                    item_label="zone",
+                    saved_items=saved_rms.zones,
+                    source_items=rms_service.get_zones(opened_rms_project),
+                )
+            )
+
+        if saved_rms.wells is not None:
+            mismatches.extend(
+                _find_rms_item_mismatches(
+                    key_prefix="rms.wells",
+                    item_label="well",
+                    saved_items=saved_rms.wells,
+                    source_items=rms_service.get_wells(opened_rms_project),
+                    ignored_fields={"planned"},
+                )
+            )
+
+        if mismatches:
+            raise RmsProjectMismatchError(mismatches)
+
+        self._fmu_dir.update_validation_metadata("rms_project")
+
+
+def _find_rms_item_mismatches(
+    *,
+    key_prefix: str,
+    item_label: str,
+    saved_items: Sequence[RmsHorizon | RmsStratigraphicZone | RmsWell],
+    source_items: Sequence[RmsHorizon | RmsStratigraphicZone | RmsWell],
+    ignored_fields: set[str] | None = None,
+) -> list[ValidationMismatch]:
+    """Find saved RMS items missing from or different in the open RMS project.
+
+    Item order is ignored. Fields in ``ignored_fields`` are excluded from the
+    comparison.
+    """
+    source_by_name = {item.name: item for item in source_items}
+    mismatches: list[ValidationMismatch] = []
+
+    for saved_item in saved_items:
+        source_item = source_by_name.get(saved_item.name)
+        saved_value = saved_item.model_dump(mode="json")
+
+        if source_item is None:
+            mismatches.append(
+                ValidationMismatch(
+                    key=f"{key_prefix}.{saved_item.name}",
+                    saved_value=saved_value,
+                    source_value=None,
+                    message=(
+                        f"RMS {item_label} '{saved_item.name}' is saved in the FMU "
+                        "project but is not present in the open RMS project."
+                    ),
+                )
+            )
+            continue
+
+        if saved_item.model_dump(
+            mode="json", exclude=ignored_fields
+        ) != source_item.model_dump(mode="json", exclude=ignored_fields):
+            mismatches.append(
+                ValidationMismatch(
+                    key=f"{key_prefix}.{saved_item.name}",
+                    saved_value=saved_value,
+                    source_value=source_item.model_dump(mode="json"),
+                    message=(
+                        f"RMS {item_label} '{saved_item.name}' has different "
+                        "settings in the FMU project and the open RMS project."
+                    ),
+                )
+            )
+
+    return mismatches

--- a/src/fmu_settings_api/v1/routes/project.py
+++ b/src/fmu_settings_api/v1/routes/project.py
@@ -38,6 +38,7 @@ from fmu_settings_api.deps import (
     ProjectServiceDep,
     ProjectServiceForRestoreDep,
     ProjectSessionServiceDep,
+    ProjectSmdaServiceDep,
     ProjectValidationServiceDep,
     RefreshLockDep,
     ResourceServiceDep,
@@ -59,9 +60,9 @@ from fmu_settings_api.models.project import (
     CacheRetention,
     GlobalConfigPath,
     LockStatus,
-    MasterdataSmdaMismatchDetail,
     RmsSimulatorMappingFilePath,
     SumoAsset,
+    ValidationMismatchDetail,
 )
 from fmu_settings_api.models.resource import CacheContent, CacheList
 from fmu_settings_api.models.rms import (
@@ -979,15 +980,16 @@ async def patch_masterdata(
 )
 async def post_validate_masterdata_smda(
     validation_service: ProjectValidationServiceDep,
+    smda_service: ProjectSmdaServiceDep,
 ) -> Message:
     """Validates saved project SMDA masterdata against SMDA."""
     try:
-        await validation_service.validate_masterdata_smda()
+        await validation_service.validate_masterdata_smda(smda_service)
         return Message(message="Validated SMDA masterdata")
     except MasterdataSmdaMismatchError as e:
         raise HTTPException(
             status_code=422,
-            detail=MasterdataSmdaMismatchDetail(
+            detail=ValidationMismatchDetail(
                 message="Project masterdata does not match SMDA",
                 mismatches=e.mismatches,
             ).model_dump(),

--- a/src/fmu_settings_api/v1/routes/rms.py
+++ b/src/fmu_settings_api/v1/routes/rms.py
@@ -13,14 +13,21 @@ from fmu.settings.models.project_config import (
 from runrms.api.proxy import RemoteException
 from runrms.exceptions import RmsProjectNotFoundError, RmsVersionError
 
-from fmu_settings_api.deps import SessionServiceDep
+from fmu_settings_api.deps import (
+    ProjectValidationServiceDep,
+    RefreshLockDep,
+    SessionServiceDep,
+    WritePermissionDep,
+)
 from fmu_settings_api.deps.rms import (
     RmsProjectDep,
     RmsProjectPathDep,
     RmsServiceDep,
 )
 from fmu_settings_api.models.common import Message
+from fmu_settings_api.models.project import ValidationMismatchDetail
 from fmu_settings_api.models.rms import RmsVersion
+from fmu_settings_api.services.project_validation import RmsProjectMismatchError
 from fmu_settings_api.session import (
     SessionNotFoundError,
 )
@@ -90,6 +97,101 @@ FailedOpeningRmsProjectResponses: Final[Responses] = {
                     "or upgrade the RMS project."
                 )
             },
+        ],
+    ),
+}
+
+RmsProjectValidationResponses: Final[Responses] = {
+    **inline_add_response(
+        403,
+        "The project configuration cannot be accessed for writing.",
+        [
+            {
+                "detail": (
+                    "Permission denied accessing .fmu at {project_fmu_directory_path}"
+                )
+            },
+        ],
+    ),
+    **inline_add_response(
+        404,
+        dedent(
+            """
+            The RMS project saved in the FMU project or its .master file could not
+            be accessed while determining its version.
+            """
+        ),
+        [
+            {"detail": "RMS project not found at '{rms_project_path}'."},
+            {
+                "detail": (
+                    "RMS version cannot be determined because the RMS project "
+                    ".master file is not found at {rms_project_path}."
+                )
+            },
+        ],
+    ),
+    **inline_add_response(
+        423,
+        "The project is not locked for writing by the current session.",
+        [
+            {"detail": "Project is not locked. Acquire the lock before writing."},
+            {
+                "detail": (
+                    "Project lock file is missing. Project is treated as read-only."
+                )
+            },
+            {
+                "detail": (
+                    "Project is read-only. Cannot write to project that is locked "
+                    "by another process."
+                )
+            },
+        ],
+    ),
+    **inline_add_response(
+        422,
+        dedent(
+            """
+            The FMU project has no saved RMS settings, the saved settings do not
+            match the open RMS project, or the RMS version cannot be used.
+            """
+        ),
+        [
+            {"detail": "No RMS settings are saved in the FMU project."},
+            {
+                "detail": {
+                    "message": "Saved RMS settings do not match the open RMS project.",
+                    "mismatches": [
+                        {
+                            "key": "rms.horizons.Top",
+                            "saved_value": {
+                                "name": "Top",
+                                "type": "interpreted",
+                            },
+                            "source_value": {
+                                "name": "Top",
+                                "type": "calculated",
+                            },
+                            "message": (
+                                "RMS horizon 'Top' has different settings in the "
+                                "FMU project and the open RMS project."
+                            ),
+                        },
+                        {
+                            "key": "rms.wells.A-1",
+                            "saved_value": {"name": "A-1", "planned": False},
+                            "source_value": None,
+                            "message": (
+                                "RMS well 'A-1' is saved in the FMU project but is "
+                                "not present in the open RMS project."
+                            ),
+                        },
+                    ],
+                }
+            },
+            {"detail": "RMS version error for project at '{rms_project_path}'"},
+            {"detail": "Failed to validate the open RMS project: {error_message}"},
         ],
     ),
 }
@@ -195,6 +297,62 @@ async def delete_rms_project(session_service: SessionServiceDep) -> Message:
         return Message(message="RMS project closed successfully")
     except SessionNotFoundError as e:
         raise HTTPException(status_code=401, detail=str(e)) from e
+
+
+@router.post(
+    "/validate",
+    response_model=Message,
+    dependencies=[WritePermissionDep, RefreshLockDep],
+    summary="Validate saved RMS settings against the open RMS project",
+    description=dedent(
+        """
+        Compare the RMS settings saved in the FMU project with the open RMS
+        project.
+
+        The operation does not modify saved RMS settings. When validation
+        succeeds, it updates RMS validation metadata in project config.
+        """
+    ),
+    responses={
+        **GetSessionResponses,
+        **RmsResponses,
+        **RmsProjectValidationResponses,
+    },
+)
+async def post_validate_rms_project(
+    project_validation_service: ProjectValidationServiceDep,
+    rms_service: RmsServiceDep,
+    opened_rms_project: RmsProjectDep,
+) -> Message:
+    """Validate saved RMS configuration against the open RMS project."""
+    try:
+        project_validation_service.validate_rms_project(
+            rms_service,
+            opened_rms_project,
+        )
+    except RmsProjectMismatchError as e:
+        raise HTTPException(
+            status_code=422,
+            detail=ValidationMismatchDetail(
+                message="Saved RMS settings do not match the open RMS project.",
+                mismatches=e.mismatches,
+            ).model_dump(),
+        ) from e
+    except RmsProjectNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except RmsVersionError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    except RemoteException as e:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Failed to validate the open RMS project: {e}",
+        ) from e
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    return Message(message="RMS project configuration validated successfully.")
 
 
 @router.get(

--- a/tests/test_services/test_project_service.py
+++ b/tests/test_services/test_project_service.py
@@ -53,7 +53,7 @@ def test_update_masterdata_updates_validation_metadata(
     """Test saving SMDA masterdata also marks it as validated."""
     service = ProjectService(fmu_dir)
     monkeypatch.setattr(
-        "fmu_settings_api.services.project.getpass.getuser",
+        "fmu.settings._fmu_dir.getpass.getuser",
         lambda: "test-user",
     )
 

--- a/tests/test_services/test_project_validation_service.py
+++ b/tests/test_services/test_project_validation_service.py
@@ -1,5 +1,6 @@
 """Tests for ProjectValidationService."""
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, Mock, call
 from uuid import UUID
@@ -7,12 +8,43 @@ from uuid import UUID
 import pytest
 from fmu.datamodels.common import Smda
 from fmu.settings import ProjectFMUDirectory
+from fmu.settings.models.project_config import (
+    RmsHorizon,
+    RmsStratigraphicZone,
+    RmsWell,
+)
 
 from fmu_settings_api.models.smda import SmdaMasterdataResult, SmdaSelectedField
 from fmu_settings_api.services.project_validation import (
     MasterdataSmdaMismatchError,
     ProjectValidationService,
+    RmsProjectMismatchError,
 )
+
+
+def _set_rms_config(
+    fmu_dir: ProjectFMUDirectory,
+    *,
+    version: str = "14.2.2",
+    horizons: list[RmsHorizon] | None = None,
+    zones: list[RmsStratigraphicZone] | None = None,
+    wells: list[RmsWell] | None = None,
+) -> None:
+    """Save RMS configuration used by validation tests."""
+    fmu_dir.set_config_value(
+        "rms",
+        {
+            "path": Path("/path/to/project.rms14.2.2"),
+            "version": version,
+            "horizons": (
+                None
+                if horizons is None
+                else [horizon.model_dump() for horizon in horizons]
+            ),
+            "zones": None if zones is None else [zone.model_dump() for zone in zones],
+            "wells": None if wells is None else [well.model_dump() for well in wells],
+        },
+    )
 
 
 def _smda_result_from_saved(
@@ -48,11 +80,11 @@ async def test_validate_masterdata_smda_updates_validation_metadata(
         return_value=_smda_result_from_saved(saved_smda)
     )
     monkeypatch.setattr(
-        "fmu_settings_api.services.project_validation.getpass.getuser",
+        "fmu.settings._fmu_dir.getpass.getuser",
         lambda: "test-user",
     )
 
-    await ProjectValidationService(fmu_dir, smda_service).validate_masterdata_smda()
+    await ProjectValidationService(fmu_dir).validate_masterdata_smda(smda_service)
 
     config = fmu_dir.config.load(force=True)
     assert config.validation.masterdata_smda is not None
@@ -92,7 +124,7 @@ async def test_validate_masterdata_smda_validates_each_saved_field(
         side_effect=lambda fields: masterdata_by_field[fields[0].identifier]
     )
 
-    await ProjectValidationService(fmu_dir, smda_service).validate_masterdata_smda()
+    await ProjectValidationService(fmu_dir).validate_masterdata_smda(smda_service)
 
     assert smda_service.get_masterdata.await_args_list == [
         call([SmdaSelectedField(identifier=field.identifier, uuid=field.uuid)])
@@ -144,7 +176,7 @@ async def test_validate_masterdata_smda_allows_extra_current_values(
         )
     )
 
-    await ProjectValidationService(fmu_dir, smda_service).validate_masterdata_smda()
+    await ProjectValidationService(fmu_dir).validate_masterdata_smda(smda_service)
 
     assert fmu_dir.config.load(force=True).validation.masterdata_smda is not None
 
@@ -165,7 +197,7 @@ async def test_validate_masterdata_smda_raises_for_mismatch(
     )
 
     with pytest.raises(MasterdataSmdaMismatchError) as exc_info:
-        await ProjectValidationService(fmu_dir, smda_service).validate_masterdata_smda()
+        await ProjectValidationService(fmu_dir).validate_masterdata_smda(smda_service)
 
     assert isinstance(exc_info.value, ValueError)
     assert exc_info.value.mismatches[0].key == "masterdata.smda.field"
@@ -193,4 +225,266 @@ async def test_validate_masterdata_smda_raises_when_masterdata_is_missing(
         ValueError,
         match="Project masterdata must be set before validating against SMDA.",
     ):
-        await ProjectValidationService(fmu_dir, smda_service).validate_masterdata_smda()
+        await ProjectValidationService(fmu_dir).validate_masterdata_smda(smda_service)
+
+
+def test_validate_rms_project_updates_validation_metadata(
+    fmu_dir: ProjectFMUDirectory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test matching RMS configuration writes a timezone-aware record."""
+    horizon = RmsHorizon(name="Top", type="interpreted")
+    zone = RmsStratigraphicZone(
+        name="Reservoir",
+        top_horizon_name="Top",
+        base_horizon_name="Base",
+        stratigraphic_column_name=["Column"],
+    )
+    well = RmsWell(name="A-1", planned=True)
+    _set_rms_config(fmu_dir, horizons=[horizon], zones=[zone], wells=[well])
+
+    rms_service = Mock()
+    rms_service.get_rms_version.return_value = "14.2.2"
+    rms_service.get_horizons.return_value = [horizon]
+    rms_service.get_zones.return_value = [zone]
+    rms_service.get_wells.return_value = [well.model_copy(update={"planned": False})]
+    monkeypatch.setattr(
+        "fmu.settings._fmu_dir.getpass.getuser",
+        lambda: "test-user",
+    )
+
+    ProjectValidationService(fmu_dir).validate_rms_project(rms_service, Mock())
+
+    record = fmu_dir.config.load(force=True).validation.rms_project
+    assert record is not None
+    assert record.last_validated_at.tzinfo is not None
+    assert record.last_validated_at.utcoffset() is not None
+    assert record.last_validated_by == "test-user"
+    rms_service.get_rms_version.assert_called_once_with(
+        Path("/path/to/project.rms14.2.2")
+    )
+    rms_service.get_horizons.assert_called_once()
+    rms_service.get_zones.assert_called_once()
+    rms_service.get_wells.assert_called_once()
+    rms_service.get_coordinate_system.assert_not_called()
+
+
+def test_validate_rms_project_accepts_configured_subsets_in_any_order(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Test additional and differently ordered RMS source items are valid."""
+    saved_horizons = [
+        RmsHorizon(name="Top", type="interpreted"),
+        RmsHorizon(name="Base", type="calculated"),
+    ]
+    saved_zones = [
+        RmsStratigraphicZone(
+            name="Reservoir",
+            top_horizon_name="Top",
+            base_horizon_name="Base",
+        )
+    ]
+    saved_wells = [RmsWell(name="A-1")]
+    _set_rms_config(
+        fmu_dir,
+        horizons=saved_horizons,
+        zones=saved_zones,
+        wells=saved_wells,
+    )
+
+    extra_horizon = RmsHorizon(name="Extra", type="calculated")
+    extra_zone = RmsStratigraphicZone(
+        name="ExtraZone",
+        top_horizon_name="Top",
+        base_horizon_name="Base",
+    )
+    rms_service = Mock()
+    rms_service.get_rms_version.return_value = "14.2.2"
+    rms_service.get_horizons.return_value = [
+        extra_horizon,
+        saved_horizons[1],
+        saved_horizons[0],
+    ]
+    rms_service.get_zones.return_value = [extra_zone, *saved_zones]
+    rms_service.get_wells.return_value = [
+        RmsWell(name="ExtraWell"),
+        RmsWell(name="A-1", planned=True),
+    ]
+
+    ProjectValidationService(fmu_dir).validate_rms_project(rms_service, Mock())
+
+    assert fmu_dir.config.load(force=True).validation.rms_project is not None
+
+
+def test_validate_rms_project_reports_all_mismatches(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Test version and item mismatches are returned together."""
+    saved_horizon = RmsHorizon(name="Top", type="interpreted")
+    saved_zone = RmsStratigraphicZone(
+        name="Reservoir",
+        top_horizon_name="Top",
+        base_horizon_name="Base",
+        stratigraphic_column_name=["Column"],
+    )
+    saved_well = RmsWell(name="A-1", planned=True)
+    _set_rms_config(
+        fmu_dir,
+        horizons=[saved_horizon],
+        zones=[saved_zone],
+        wells=[saved_well],
+    )
+    current_horizon = saved_horizon.model_copy(update={"type": "calculated"})
+    current_zone = saved_zone.model_copy(update={"top_horizon_name": "ChangedTop"})
+    rms_service = Mock()
+    rms_service.get_rms_version.return_value = "14.3"
+    rms_service.get_horizons.return_value = [current_horizon]
+    rms_service.get_zones.return_value = [current_zone]
+    rms_service.get_wells.return_value = []
+
+    with pytest.raises(RmsProjectMismatchError) as exc_info:
+        ProjectValidationService(fmu_dir).validate_rms_project(rms_service, Mock())
+
+    mismatches = exc_info.value.mismatches
+    assert [mismatch.key for mismatch in mismatches] == [
+        "rms.version",
+        "rms.horizons.Top",
+        "rms.zones.Reservoir",
+        "rms.wells.A-1",
+    ]
+    assert [mismatch.message for mismatch in mismatches] == [
+        "The RMS version saved in the FMU project does not match the version of "
+        "the open RMS project.",
+        "RMS horizon 'Top' has different settings in the FMU project and the "
+        "open RMS project.",
+        "RMS zone 'Reservoir' has different settings in the FMU project and the "
+        "open RMS project.",
+        "RMS well 'A-1' is saved in the FMU project but is not present in the "
+        "open RMS project.",
+    ]
+    assert mismatches[0].saved_value == "14.2.2"
+    assert mismatches[0].source_value == "14.3"
+    assert mismatches[1].saved_value == saved_horizon.model_dump(mode="json")
+    assert mismatches[1].source_value == current_horizon.model_dump(mode="json")
+    assert mismatches[2].saved_value == saved_zone.model_dump(mode="json")
+    assert mismatches[2].source_value == current_zone.model_dump(mode="json")
+    assert mismatches[3].saved_value == saved_well.model_dump(mode="json")
+    assert mismatches[3].source_value is None
+    assert fmu_dir.config.load(force=True).validation.rms_project is None
+
+
+def test_validate_rms_project_reports_missing_horizon_and_zone(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Test configured horizons and zones missing from RMS are reported."""
+    saved_horizon = RmsHorizon(name="Top", type="interpreted")
+    saved_zone = RmsStratigraphicZone(
+        name="Reservoir",
+        top_horizon_name="Top",
+        base_horizon_name="Base",
+    )
+    _set_rms_config(fmu_dir, horizons=[saved_horizon], zones=[saved_zone])
+    rms_service = Mock()
+    rms_service.get_rms_version.return_value = "14.2.2"
+    rms_service.get_horizons.return_value = []
+    rms_service.get_zones.return_value = []
+
+    with pytest.raises(RmsProjectMismatchError) as exc_info:
+        ProjectValidationService(fmu_dir).validate_rms_project(rms_service, Mock())
+
+    mismatches = exc_info.value.mismatches
+    assert [mismatch.key for mismatch in mismatches] == [
+        "rms.horizons.Top",
+        "rms.zones.Reservoir",
+    ]
+    assert all(mismatch.source_value is None for mismatch in mismatches)
+
+
+def test_validate_rms_project_does_not_read_unsaved_categories(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Test validation does not read categories that are not saved in config."""
+    _set_rms_config(fmu_dir)
+    rms_service = Mock()
+    rms_service.get_rms_version.return_value = "14.2.2"
+
+    ProjectValidationService(fmu_dir).validate_rms_project(rms_service, Mock())
+
+    rms_service.get_rms_version.assert_called_once()
+    rms_service.get_horizons.assert_not_called()
+    rms_service.get_zones.assert_not_called()
+    rms_service.get_wells.assert_not_called()
+    rms_service.get_coordinate_system.assert_not_called()
+
+
+def test_validate_rms_project_accepts_empty_saved_horizon_zone_and_well_lists(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Test validation succeeds when no horizons, zones, or wells are saved."""
+    _set_rms_config(fmu_dir, horizons=[], zones=[], wells=[])
+    rms_service = Mock()
+    rms_service.get_rms_version.return_value = "14.2.2"
+    rms_service.get_horizons.return_value = [
+        RmsHorizon(name="Extra", type="calculated")
+    ]
+    rms_service.get_zones.return_value = [
+        RmsStratigraphicZone(
+            name="ExtraZone",
+            top_horizon_name="Top",
+            base_horizon_name="Base",
+        )
+    ]
+    rms_service.get_wells.return_value = [RmsWell(name="ExtraWell")]
+
+    ProjectValidationService(fmu_dir).validate_rms_project(rms_service, Mock())
+
+    assert fmu_dir.config.load(force=True).validation.rms_project is not None
+
+
+def test_validate_rms_project_requires_rms_configuration(
+    fmu_dir: ProjectFMUDirectory,
+) -> None:
+    """Test missing RMS configuration does not access RMS or write metadata."""
+    rms_service = Mock()
+
+    with pytest.raises(
+        ValueError,
+        match="No RMS settings are saved in the FMU project.",
+    ):
+        ProjectValidationService(fmu_dir).validate_rms_project(rms_service, Mock())
+
+    rms_service.get_rms_version.assert_not_called()
+    rms_service.get_horizons.assert_not_called()
+    rms_service.get_zones.assert_not_called()
+    rms_service.get_wells.assert_not_called()
+    assert fmu_dir.config.load(force=True).validation.rms_project is None
+
+
+def test_validate_rms_project_preserves_previous_metadata_and_config(
+    fmu_dir: ProjectFMUDirectory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a failed validation does not overwrite metadata or RMS config."""
+    saved_well = RmsWell(name="A-1")
+    _set_rms_config(fmu_dir, wells=[saved_well])
+    rms_service = Mock()
+    rms_service.get_rms_version.return_value = "14.2.2"
+    rms_service.get_wells.return_value = [saved_well]
+    monkeypatch.setattr(
+        "fmu.settings._fmu_dir.getpass.getuser",
+        lambda: "test-user",
+    )
+    service = ProjectValidationService(fmu_dir)
+    service.validate_rms_project(rms_service, Mock())
+    previous_record = fmu_dir.config.load(force=True).validation.rms_project
+    saved_rms_before_failure = fmu_dir.config.load().rms
+    assert previous_record is not None
+    assert saved_rms_before_failure is not None
+
+    rms_service.get_wells.return_value = []
+    with pytest.raises(RmsProjectMismatchError):
+        service.validate_rms_project(rms_service, Mock())
+
+    config_after_failure = fmu_dir.config.load(force=True)
+    assert config_after_failure.validation.rms_project == previous_record
+    assert config_after_failure.rms == saved_rms_before_failure

--- a/tests/test_v1/test_project.py
+++ b/tests/test_v1/test_project.py
@@ -1089,7 +1089,7 @@ async def test_patch_masterdata_general_exception(
 
 
 async def test_post_validate_masterdata_smda_success(
-    client_with_project_session: TestClient,
+    client_with_smda_session: TestClient,
 ) -> None:
     """Test validating SMDA masterdata returns a success message."""
     validation_service = Mock()
@@ -1098,15 +1098,15 @@ async def test_post_validate_masterdata_smda_success(
         validation_service
     )
 
-    response = client_with_project_session.post(f"{ROUTE}/validate/masterdata/smda")
+    response = client_with_smda_session.post(f"{ROUTE}/validate/masterdata/smda")
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"message": "Validated SMDA masterdata"}
-    validation_service.validate_masterdata_smda.assert_awaited_once_with()
+    validation_service.validate_masterdata_smda.assert_awaited_once()
 
 
 async def test_post_validate_masterdata_smda_missing_masterdata_error(
-    client_with_project_session: TestClient,
+    client_with_smda_session: TestClient,
 ) -> None:
     """Test validating SMDA masterdata maps missing masterdata to 422."""
     validation_service = Mock()
@@ -1119,18 +1119,18 @@ async def test_post_validate_masterdata_smda_missing_masterdata_error(
         validation_service
     )
 
-    response = client_with_project_session.post(f"{ROUTE}/validate/masterdata/smda")
+    response = client_with_smda_session.post(f"{ROUTE}/validate/masterdata/smda")
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     assert (
         response.json()["detail"]
         == "Project masterdata must be set before validating against SMDA."
     )
-    validation_service.validate_masterdata_smda.assert_awaited_once_with()
+    validation_service.validate_masterdata_smda.assert_awaited_once()
 
 
 async def test_post_validate_masterdata_smda_mismatch_error(
-    client_with_project_session: TestClient,
+    client_with_smda_session: TestClient,
 ) -> None:
     """Test validating SMDA masterdata maps mismatch details to 422."""
     mismatch = ValidationMismatch(
@@ -1149,18 +1149,18 @@ async def test_post_validate_masterdata_smda_mismatch_error(
         validation_service
     )
 
-    response = client_with_project_session.post(f"{ROUTE}/validate/masterdata/smda")
+    response = client_with_smda_session.post(f"{ROUTE}/validate/masterdata/smda")
 
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     assert response.json()["detail"] == {
         "message": "Project masterdata does not match SMDA",
         "mismatches": [mismatch.model_dump(mode="json")],
     }
-    validation_service.validate_masterdata_smda.assert_awaited_once_with()
+    validation_service.validate_masterdata_smda.assert_awaited_once()
 
 
 async def test_post_validate_masterdata_smda_smda_http_error(
-    client_with_project_session: TestClient,
+    client_with_smda_session: TestClient,
 ) -> None:
     """Test validating SMDA masterdata maps SMDA HTTP errors."""
     request = httpx2.Request("GET", "https://smda.example.test/masterdata")
@@ -1175,7 +1175,7 @@ async def test_post_validate_masterdata_smda_smda_http_error(
         validation_service
     )
 
-    api_response = client_with_project_session.post(f"{ROUTE}/validate/masterdata/smda")
+    api_response = client_with_smda_session.post(f"{ROUTE}/validate/masterdata/smda")
 
     assert api_response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert api_response.json()["detail"] == (
@@ -1185,11 +1185,11 @@ async def test_post_validate_masterdata_smda_smda_http_error(
         api_response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
         == HttpHeader.UPSTREAM_SOURCE_SMDA
     )
-    validation_service.validate_masterdata_smda.assert_awaited_once_with()
+    validation_service.validate_masterdata_smda.assert_awaited_once()
 
 
 async def test_post_validate_masterdata_smda_timeout_error(
-    client_with_project_session: TestClient,
+    client_with_smda_session: TestClient,
 ) -> None:
     """Test validating SMDA masterdata maps SMDA timeouts."""
     validation_service = Mock()
@@ -1198,7 +1198,7 @@ async def test_post_validate_masterdata_smda_timeout_error(
         validation_service
     )
 
-    response = client_with_project_session.post(f"{ROUTE}/validate/masterdata/smda")
+    response = client_with_smda_session.post(f"{ROUTE}/validate/masterdata/smda")
 
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert response.json()["detail"] == "SMDA API request timed out. Please try again."
@@ -1206,11 +1206,11 @@ async def test_post_validate_masterdata_smda_timeout_error(
         response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
         == HttpHeader.UPSTREAM_SOURCE_SMDA
     )
-    validation_service.validate_masterdata_smda.assert_awaited_once_with()
+    validation_service.validate_masterdata_smda.assert_awaited_once()
 
 
 async def test_post_validate_masterdata_smda_malformed_smda_response(
-    client_with_project_session: TestClient,
+    client_with_smda_session: TestClient,
 ) -> None:
     """Test validating SMDA masterdata maps malformed SMDA responses."""
     validation_service = Mock()
@@ -1221,7 +1221,7 @@ async def test_post_validate_masterdata_smda_malformed_smda_response(
         validation_service
     )
 
-    response = client_with_project_session.post(f"{ROUTE}/validate/masterdata/smda")
+    response = client_with_smda_session.post(f"{ROUTE}/validate/masterdata/smda")
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert response.json()["detail"] == "Malformed response from SMDA: 'field'"
@@ -1229,7 +1229,7 @@ async def test_post_validate_masterdata_smda_malformed_smda_response(
         response.headers[HttpHeader.UPSTREAM_SOURCE_KEY]
         == HttpHeader.UPSTREAM_SOURCE_SMDA
     )
-    validation_service.validate_masterdata_smda.assert_awaited_once_with()
+    validation_service.validate_masterdata_smda.assert_awaited_once()
 
 
 async def test_load_global_config_from_default_path(

--- a/tests/test_v1/test_rms.py
+++ b/tests/test_v1/test_rms.py
@@ -10,13 +10,21 @@ from runrms.api.proxy import RemoteException
 from runrms.exceptions import RmsProjectNotFoundError, RmsVersionError
 
 from fmu_settings_api.__main__ import app
+from fmu_settings_api.config import settings
 from fmu_settings_api.deps.rms import (
     get_opened_rms_project,
     get_rms_project_path,
     get_rms_service,
 )
 from fmu_settings_api.deps.session import get_session_service
-from fmu_settings_api.session import SessionNotFoundError
+from fmu_settings_api.deps.validation import get_project_validation_service
+from fmu_settings_api.models.project import ValidationMismatch
+from fmu_settings_api.services.project_validation import RmsProjectMismatchError
+from fmu_settings_api.session import (
+    ProjectSession,
+    SessionNotFoundError,
+    get_fmu_session,
+)
 
 ROUTE = "/api/v1/rms"
 
@@ -399,6 +407,254 @@ async def test_close_rms_project_no_session() -> None:
         response = client.delete(f"{ROUTE}/")
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json()["detail"] == "No active session found"
+
+
+async def test_validate_rms_project_success(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test RMS validation returns success."""
+    validation_service = MagicMock()
+    rms_service = MagicMock()
+    opened_rms_project = MagicMock()
+    app.dependency_overrides[get_project_validation_service] = lambda: (
+        validation_service
+    )
+    app.dependency_overrides[get_rms_service] = lambda: rms_service
+    app.dependency_overrides[get_opened_rms_project] = lambda: opened_rms_project
+
+    response = client_with_project_session.post(f"{ROUTE}/validate")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "message": "RMS project configuration validated successfully."
+    }
+    validation_service.validate_rms_project.assert_called_once_with(
+        rms_service,
+        opened_rms_project,
+    )
+
+
+async def test_validate_rms_project_mismatch_returns_structured_422(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test RMS mismatch details are returned as a structured 422 response."""
+    mismatch = ValidationMismatch(
+        key="rms.wells.A-1",
+        saved_value={"name": "A-1", "planned": False},
+        source_value=None,
+        message=(
+            "RMS well 'A-1' is saved in the FMU project but is not present in the "
+            "open RMS project."
+        ),
+    )
+    validation_service = MagicMock()
+    validation_service.validate_rms_project.side_effect = RmsProjectMismatchError(
+        [mismatch]
+    )
+    app.dependency_overrides[get_project_validation_service] = lambda: (
+        validation_service
+    )
+    app.dependency_overrides[get_rms_service] = lambda: MagicMock()
+    app.dependency_overrides[get_opened_rms_project] = lambda: MagicMock()
+
+    response = client_with_project_session.post(f"{ROUTE}/validate")
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert response.json()["detail"] == {
+        "message": "Saved RMS settings do not match the open RMS project.",
+        "mismatches": [mismatch.model_dump(mode="json")],
+    }
+
+
+async def test_validate_rms_project_missing_configuration_returns_422(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test missing RMS configuration maps to 422."""
+    validation_service = MagicMock()
+    validation_service.validate_rms_project.side_effect = ValueError(
+        "No RMS settings are saved in the FMU project."
+    )
+    app.dependency_overrides[get_project_validation_service] = lambda: (
+        validation_service
+    )
+    app.dependency_overrides[get_rms_service] = lambda: MagicMock()
+    app.dependency_overrides[get_opened_rms_project] = lambda: MagicMock()
+
+    response = client_with_project_session.post(f"{ROUTE}/validate")
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert response.json() == {
+        "detail": "No RMS settings are saved in the FMU project."
+    }
+
+
+async def test_validate_rms_project_not_found_returns_404(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test a missing RMS project maps to 404."""
+    validation_service = MagicMock()
+    validation_service.validate_rms_project.side_effect = RmsProjectNotFoundError(
+        "RMS project not found."
+    )
+    app.dependency_overrides[get_project_validation_service] = lambda: (
+        validation_service
+    )
+    app.dependency_overrides[get_rms_service] = lambda: MagicMock()
+    app.dependency_overrides[get_opened_rms_project] = lambda: MagicMock()
+
+    response = client_with_project_session.post(f"{ROUTE}/validate")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "RMS project not found."}
+
+
+async def test_validate_rms_project_missing_master_file_returns_404(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test a missing RMS project master file maps to 404."""
+    validation_service = MagicMock()
+    validation_service.validate_rms_project.side_effect = FileNotFoundError(
+        "RMS project master file not found."
+    )
+    app.dependency_overrides[get_project_validation_service] = lambda: (
+        validation_service
+    )
+    app.dependency_overrides[get_rms_service] = lambda: MagicMock()
+    app.dependency_overrides[get_opened_rms_project] = lambda: MagicMock()
+
+    response = client_with_project_session.post(f"{ROUTE}/validate")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {"detail": "RMS project master file not found."}
+
+
+async def test_validate_rms_project_version_error_returns_422(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test an unsupported RMS version maps to 422."""
+    validation_service = MagicMock()
+    validation_service.validate_rms_project.side_effect = RmsVersionError(
+        "RMS version is not supported."
+    )
+    app.dependency_overrides[get_project_validation_service] = lambda: (
+        validation_service
+    )
+    app.dependency_overrides[get_rms_service] = lambda: MagicMock()
+    app.dependency_overrides[get_opened_rms_project] = lambda: MagicMock()
+
+    response = client_with_project_session.post(f"{ROUTE}/validate")
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert response.json() == {"detail": "RMS version is not supported."}
+
+
+async def test_validate_rms_project_remote_error_returns_422(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test an RMS API error maps to 422."""
+    validation_service = MagicMock()
+    remote_error = RemoteException(message="RMS API request failed.")
+    validation_service.validate_rms_project.side_effect = remote_error
+    app.dependency_overrides[get_project_validation_service] = lambda: (
+        validation_service
+    )
+    app.dependency_overrides[get_rms_service] = lambda: MagicMock()
+    app.dependency_overrides[get_opened_rms_project] = lambda: MagicMock()
+
+    response = client_with_project_session.post(f"{ROUTE}/validate")
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert response.json() == {
+        "detail": f"Failed to validate the open RMS project: {remote_error}"
+    }
+
+
+async def test_validate_rms_project_requires_open_rms_project(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test validation uses the existing 400 response when RMS is not open."""
+    validation_service = MagicMock()
+    app.dependency_overrides[get_project_validation_service] = lambda: (
+        validation_service
+    )
+    app.dependency_overrides[get_rms_service] = lambda: MagicMock()
+
+    response = client_with_project_session.post(f"{ROUTE}/validate")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "detail": "No RMS project is currently open. Please open an RMS project first."
+    }
+    validation_service.validate_rms_project.assert_not_called()
+
+
+async def test_validate_rms_project_requires_project_session() -> None:
+    """Test validation uses the existing 401 response without a project session."""
+    with TestClient(app) as client:
+        response = client.post(f"{ROUTE}/validate")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json()["detail"] == "No active session found"
+
+
+async def test_validate_rms_project_requires_write_permission(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test validation is blocked when the project is not locked."""
+    session_id = client_with_project_session.cookies.get(settings.SESSION_COOKIE_KEY)
+    assert session_id is not None
+    session = await get_fmu_session(session_id)
+    assert isinstance(session, ProjectSession)
+    lock = MagicMock()
+    lock.is_locked.return_value = False
+    session.project_fmu_directory._lock = lock
+
+    validation_service = MagicMock()
+    app.dependency_overrides[get_project_validation_service] = lambda: (
+        validation_service
+    )
+    app.dependency_overrides[get_rms_service] = lambda: MagicMock()
+    app.dependency_overrides[get_opened_rms_project] = lambda: MagicMock()
+
+    response = client_with_project_session.post(f"{ROUTE}/validate")
+
+    assert response.status_code == status.HTTP_423_LOCKED
+    assert response.json() == {
+        "detail": "Project is not locked. Acquire the lock before writing."
+    }
+    validation_service.validate_rms_project.assert_not_called()
+
+
+async def test_validate_rms_project_requires_project_lock(
+    client_with_project_session: TestClient,
+) -> None:
+    """Test validation is blocked when another process holds the lock."""
+    session_id = client_with_project_session.cookies.get(settings.SESSION_COOKIE_KEY)
+    assert session_id is not None
+    session = await get_fmu_session(session_id)
+    assert isinstance(session, ProjectSession)
+    lock = MagicMock()
+    lock.is_locked.return_value = True
+    lock.is_acquired.return_value = False
+    session.project_fmu_directory._lock = lock
+
+    validation_service = MagicMock()
+    app.dependency_overrides[get_project_validation_service] = lambda: (
+        validation_service
+    )
+    app.dependency_overrides[get_rms_service] = lambda: MagicMock()
+    app.dependency_overrides[get_opened_rms_project] = lambda: MagicMock()
+
+    response = client_with_project_session.post(f"{ROUTE}/validate")
+
+    assert response.status_code == status.HTTP_423_LOCKED
+    assert response.json() == {
+        "detail": (
+            "Project is read-only. Cannot write to project that is locked by "
+            "another process."
+        )
+    }
+    validation_service.validate_rms_project.assert_not_called()
 
 
 async def test_get_zones_success(

--- a/tests/test_v1/test_validation_deps.py
+++ b/tests/test_v1/test_validation_deps.py
@@ -11,12 +11,7 @@ async def test_get_project_validation_service() -> None:
     project_session = MagicMock()
     project_fmu_directory = MagicMock()
     project_session.project_fmu_directory = project_fmu_directory
-    smda_service = MagicMock()
-
-    validation_service = await get_project_validation_service(
-        project_session, smda_service
-    )
+    validation_service = await get_project_validation_service(project_session)
 
     assert isinstance(validation_service, ProjectValidationService)
     assert validation_service._fmu_dir is project_fmu_directory
-    assert validation_service._smda_service is smda_service

--- a/uv.lock
+++ b/uv.lock
@@ -316,19 +316,19 @@ wheels = [
 
 [[package]]
 name = "fmu-datamodels"
-version = "0.23.1"
+version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/1c/3e21c1b0f508415c2af87e2f7bdd2e9f5a66a871d18c0baf8ef947854025/fmu_datamodels-0.23.1.tar.gz", hash = "sha256:9008863bd0f1cd934251de56409592412de19c886ed6f5dd2d04d99fe5f89058", size = 440561, upload-time = "2026-06-24T11:58:10.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/4d/45418123021187d909282ae8e329f17008ec0bb36079dbe46ad0604566d1/fmu_datamodels-0.24.0.tar.gz", hash = "sha256:0df0aa787743326fd502e947fce90a5adf2d6f046ba6545a1a775b97e185c41f", size = 454550, upload-time = "2026-08-10T10:46:13.896Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/d5/08a6eb140947d9b4553f59cbc261406a9f6e59a53b4584907d58b328de4d/fmu_datamodels-0.23.1-py3-none-any.whl", hash = "sha256:4ee675e1ee356ebdde86904313c60a2b58bf05a74c70e2f65e09bcdc7ca11ee7", size = 59525, upload-time = "2026-06-24T11:58:08.969Z" },
+    { url = "https://files.pythonhosted.org/packages/28/19/13815ca8d95cc956b026edb7c8fab71598cc7f19d1428fb774d36b3c23ca/fmu_datamodels-0.24.0-py3-none-any.whl", hash = "sha256:0bb601142c9bdd70607f61f0030b99b57ae8e032e24545872b48143a3fe60d90", size = 58099, upload-time = "2026-08-10T10:46:12.503Z" },
 ]
 
 [[package]]
 name = "fmu-settings"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -338,9 +338,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/48/467e87b3d43ed01ed2171986bed0447aad615e4ffc3ab23e9002a14d7d76/fmu_settings-1.0.0.tar.gz", hash = "sha256:36c28b799dae639cc64ce2b896168ca7cb870384d32865a44c2248ae25dfb723", size = 783965, upload-time = "2026-06-29T09:59:40.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/bc/91d05523390ad7b0154bf7c6e65f46a8b96c0742e401e690f50cd46fbca5/fmu_settings-1.1.0.tar.gz", hash = "sha256:5de87fa384fadf28bb4468381d9b5d05a1830b458b5d4f17975c6fa5f8de1748", size = 784361, upload-time = "2026-08-11T07:14:25.128Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/00/80c5bbb439b258295914b36c58385c62c9acda9ca97e057c343be5af387e/fmu_settings-1.0.0-py3-none-any.whl", hash = "sha256:829657aeb63bbfd10a45227b827233096f8eeb89cfdede3cf982eb9b42717a31", size = 64017, upload-time = "2026-06-29T09:59:38.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/91/5ba9a7dad19ca6e556165bd4d3e3c914a89f75be6dae7d32b67c1c1f7be1/fmu_settings-1.1.0-py3-none-any.whl", hash = "sha256:dda8c4ad79b36bc200af2678f5e542143f28616689e7f11add044a04749a8377", size = 63129, upload-time = "2026-08-11T07:14:23.683Z" },
 ]
 
 [[package]]
@@ -380,7 +380,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.138.0" },
     { name = "fmu-datamodels", specifier = ">=0.21.4" },
-    { name = "fmu-settings", specifier = ">=1.0.0" },
+    { name = "fmu-settings", specifier = ">=1.1.0" },
     { name = "fmu-settings-cli", marker = "extra == 'dev'" },
     { name = "httpx2" },
     { name = "mypy", marker = "extra == 'dev'" },
@@ -423,15 +423,11 @@ wheels = [
 
 [[package]]
 name = "fmu-settings-gui"
-version = "0.9.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastapi" },
-    { name = "uvicorn" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/34/440166025640e9b1e76f87be2ba4ef52367414339655531c2c1b7ee82bdd/fmu_settings_gui-0.9.0.tar.gz", hash = "sha256:d1edc1e07c572c2b5469b581eb598533c95b17f382c7abc59d7f8334a9724e08", size = 677794, upload-time = "2026-05-20T10:35:14.175Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/f0/8ba90a254c2da3d75e1378fe55c20759e924d506eea9325562692fef9d8b/fmu_settings_gui-1.1.0.tar.gz", hash = "sha256:99d7f5de9c84413c61b7e5e58ffb0bba995cfc2bc248fe390f148e29027a5acc", size = 732269, upload-time = "2026-07-30T13:06:26.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/1d/48d3bb2f7f8aef6388e6c8bb88b34794f81d0b235cf63447c790215b6556/fmu_settings_gui-0.9.0-py3-none-any.whl", hash = "sha256:ce5b280fc3aafd605ceb134a127250409dca7438d75de0d97f0cda34d082b19d", size = 463773, upload-time = "2026-05-20T10:35:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/74/6bcb8b765514450184b532f6523ac660fc694a3b9c4c22b3d6255a80c290/fmu_settings_gui-1.1.0-py3-none-any.whl", hash = "sha256:726a56f57db0f321058d5a4020f544fa50c252e704f6142e65a0b9f11dea450c", size = 489344, upload-time = "2026-07-30T13:06:24.989Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #443 

Added `POST /api/v1/rms/validate` to compare saved RMS settings with the open RMS project.

The validation:

- compares the RMS version, horizons, zones, and wells
- ignores item order
- ignores the `planned` field when comparing wells
- returns all mismatches in a structured 422 response
- updates validation metadata only after successful validation
- preserves existing metadata and configuration after failed validation

The project RMS patch endpoints do not update RMS validation metadata because each endpoint saves only part of the RMS configuration. Unlike these endpoints, the masterdata patch saves the complete masterdata configuration, so it can update validation metadata.

The shared project validation service no longer requires SMDA access unless SMDA masterdata validation is requested.

The minimum `fmu-settings` version is updated to 1.1.0 to use the `update_validation_metadata()` method.

This issue https://github.com/equinor/fmu-settings-gui/issues/507 described some ideas on how to show the validation metadata and what happens when there are mismatches.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
