### PR TITLE
ENH: Add Kvitebjorn to sumo_assets.json

### DIFF
--- a/src/fmu_settings_api/interfaces/sumo_assets.json
+++ b/src/fmu_settings_api/interfaces/sumo_assets.json
@@ -198,5 +198,10 @@
         "name": "Kalundborg",
         "code": "040",
         "roleprefix": "KALUNDBORG"
+    },
+    {
+        "name": "Kvitebjørn",
+        "code": "041",
+        "roleprefix": "KVITEBJORN"
     }
 ]


### PR DESCRIPTION
This PR adds Kvitebjorn to the list of assets recognized by fmu-settings.